### PR TITLE
Add blood moon omen and cosmetics

### DIFF
--- a/src/ReplicatedStorage/Remotes/Net.lua
+++ b/src/ReplicatedStorage/Remotes/Net.lua
@@ -23,4 +23,8 @@ return {
 	PerfPing      = get("PerfPing","RemoteFunction"),
 	AdminAction   = get("AdminAction","RemoteFunction"),
 	AdminSetConfig= get("AdminSetConfig","RemoteFunction"),
+	ListCosmetics = get("ListCosmetics","RemoteFunction"),
+	BuyCosmetic   = get("BuyCosmetic","RemoteFunction"),
+	EquipCosmetic = get("EquipCosmetic","RemoteFunction"),
+	PatchNotesEvt = get("PatchNotesEvt","RemoteEvent"),
 }

--- a/src/ReplicatedStorage/Shared/Config/Cosmetics.lua
+++ b/src/ReplicatedStorage/Shared/Config/Cosmetics.lua
@@ -1,0 +1,13 @@
+-- Simple catalog (IDs are keys). Type: "camp" or "outfit".
+return {
+  Items = {
+    camp_moonlit  = { type="camp",  name="Moonlit Camp",  cost=25 },
+    camp_ember    = { type="camp",  name="Ember Camp",    cost=25 },
+    outfit_midnight={ type="outfit",name="Midnight Fit",  cost=15 },
+    outfit_ashen  = { type="outfit",name="Ashen Fit",     cost=15 },
+    camp_bloodmoon= { type="camp",  name="Blood Moon Camp", cost=40 },
+    outfit_aurora = { type="outfit",name="Aurora Fit",    cost=20 },
+  },
+  -- Deterministic daily rotation (pick N per day)
+  DailyCount = 4
+}

--- a/src/ReplicatedStorage/Shared/Config/PatchNotes.lua
+++ b/src/ReplicatedStorage/Shared/Config/PatchNotes.lua
@@ -1,0 +1,10 @@
+return {
+  version = "0.9.0",
+  title = "Blood Moon Update",
+  bullets = {
+    "New Omen: Blood Moon — enemies are quicker and the night runs red.",
+    "Cosmetics: unlock camp skins and outfit tints with shards.",
+    "Daily rotation shop with fair prices.",
+    "Performance polish & bug fixes.",
+  }
+}

--- a/src/ReplicatedStorage/Shared/Config/Tuning.lua
+++ b/src/ReplicatedStorage/Shared/Config/Tuning.lua
@@ -3,4 +3,25 @@ local M = {
 	waveCap = 80,
 	dropRates = { shard=1.0 },
 }
+M.get = function()
+	return M
+end
+
+local function ensureProfiles()
+	M.Profiles = M.Profiles or {}
+	local names = { "Normal", "Challenging", "Hardcore" }
+	for _, name in ipairs(names) do
+		local profile = M.Profiles[name] or {}
+		profile.Omen = profile.Omen or {}
+		profile.Omen.BloodMoon = profile.Omen.BloodMoon or { speedMult = 1.15, extraFuel = 2, splitChance = 0.15 }
+		M.Profiles[name] = profile
+	end
+end
+
+ensureProfiles()
+
+M.Omen = M.Omen or {}
+if not M.Omen.BloodMoon then
+	M.Omen.BloodMoon = { speedMult = 1.15, extraFuel = 2, splitChance = 0.15 }
+end
 return M

--- a/src/ReplicatedStorage/Systems/S_HealthDeath.server.lua
+++ b/src/ReplicatedStorage/Systems/S_HealthDeath.server.lua
@@ -7,6 +7,9 @@ local Loot = require(Rep.Components.C_Loot)
 local BeaconService = require(game.ServerScriptService.Services.BeaconService)
 local DataService = require(game.ServerScriptService.Services.DataService)
 local Net = require(Rep.Remotes.Net)
+local OmenService = require(game.ServerScriptService.Services.OmenService)
+local AISpawner = require(game.ServerScriptService.Services.AISpawnerService)
+local Tuning = require(Rep.Shared.Config.Tuning)
 
 return function(world, dt)
 	for id, hp, ref, et in world:query(Health, InstanceRef, EnemyType) do
@@ -27,6 +30,14 @@ return function(world, dt)
 				end
 			end
 			Net.SpawnVFX:FireAllClients({ kind="text", part = ref.inst, text = "+Shards" })
+			local function trySplit()
+				if not OmenService.Is("BloodMoon") then return end
+				local O = (Tuning.get().Omen and Tuning.get().Omen.BloodMoon) or { splitChance = 0.15 }
+				if math.random() < (O.splitChance or 0.15) and ref and ref.inst then
+					AISpawner.spawn({ budget=1, squads={{ type="Swarmling", count=1 }} })
+				end
+			end
+			trySplit()
 			-- Cleanup
 			if ref.inst and ref.inst.Parent then ref.inst:Destroy() end
 			world:despawn(id)

--- a/src/ServerScriptService/Server/NetBindings.server.lua
+++ b/src/ServerScriptService/Server/NetBindings.server.lua
@@ -1,6 +1,7 @@
 local Rep = game:GetService("ReplicatedStorage")
 
 local Remotes = require(game.ServerScriptService.Net.Remotes)
+local Net = require(Rep.Remotes.Net)
 local Validators = require(Rep.Shared.Net.Validators)
 local AdminGuard = require(game.ServerScriptService.Security.AdminGuard)
 local Throttle = require(script.Parent.Throttle)
@@ -15,6 +16,7 @@ local Analytics = require(game.ServerScriptService.Services.AnalyticsAdapter)
 local TutorialService = require(game.ServerScriptService.Services.TutorialService)
 local GameService = require(game.ServerScriptService.Services.GameService)
 local RescueService = require(game.ServerScriptService.Services.RescueService)
+local Cosmetics = require(game.ServerScriptService.Services.CosmeticsService)
 
 local function throttleDenied()
 	return false, "throttled"
@@ -119,6 +121,20 @@ Remotes.registerFunction(
 	end,
 	{ capacity = 4, refill = 0.5 }
 )
+
+Net.ListCosmetics.OnServerInvoke = function(player)
+	return Cosmetics.GetShop(player)
+end
+
+Net.BuyCosmetic.OnServerInvoke = function(player, id)
+	local ok, why = Cosmetics.Buy(player, id)
+	return ok, why
+end
+
+Net.EquipCosmetic.OnServerInvoke = function(player, id)
+	local ok, why = Cosmetics.Equip(player, id)
+	return ok, why
+end
 
 Remotes.registerFunction(
 	"PerfPing",

--- a/src/ServerScriptService/Server/Server.main.server.lua
+++ b/src/ServerScriptService/Server/Server.main.server.lua
@@ -31,10 +31,12 @@ local GameService = require(ServicesFolder.GameService)
 local DataService = require(ServicesFolder.DataService)
 local BeaconService = require(ServicesFolder.BeaconService)
 local TutorialService = require(ServicesFolder.TutorialService)
+local PatchNotes = require(ServicesFolder.PatchNotesService)
 
 game.Players.PlayerAdded:Connect(function(plr)
 	DataService.LoadProfileAsync(plr)
 	TutorialService.Begin(plr)
+	PatchNotes.PushIfNew(plr)
 end)
 game.Players.PlayerRemoving:Connect(function(plr) DataService.SaveProfileAsync(plr) end)
 

--- a/src/ServerScriptService/Services/AISpawnerService.lua
+++ b/src/ServerScriptService/Services/AISpawnerService.lua
@@ -16,6 +16,7 @@ local Boss = require(Rep.Components.C_Boss)
 
 local AssetLoader = require(script.Parent.AssetLoader)
 local SpawnPoints = require(script.Parent.SpawnPointService)
+local OmenService = require(script.Parent.OmenService)
 
 local M = {}
 local active = 0
@@ -52,6 +53,9 @@ local function spawnOne(kind, position)
 	part.Destroying:Connect(function() active -= 1 end)
 
 	local speed = SPEED_BY_KIND[kind] or 12
+	if OmenService.Is("BloodMoon") then
+		speed = math.floor(speed * 1.15)
+	end
 	local dmg = DMG_BY_KIND[kind] or 6
 
 	local comps = {

--- a/src/ServerScriptService/Services/BeaconService.lua
+++ b/src/ServerScriptService/Services/BeaconService.lua
@@ -1,6 +1,8 @@
 local Rep = game:GetService("ReplicatedStorage")
 local Net = require(Rep.Remotes.Net)
 local C = require(Rep.Shared.Constants)
+local Tuning = require(Rep.Shared.Config.Tuning)
+local OmenService = require(script.Parent.OmenService)
 
 local M = {}
 local state = { fuel = 100, heat = 100, lightRadius = 90, stability = 1, mods = {} }
@@ -50,7 +52,12 @@ function M.OnDayStart()
 end
 
 function M.OnNightStart()
-	state.fuel = clamp(state.fuel - C.Beacon.FuelDrainPerNight, 0, 100)
+  local extra = 0
+  if OmenService.Is("BloodMoon") then
+    local O = (Tuning.get().Omen and Tuning.get().Omen.BloodMoon) or { extraFuel = 2 }
+    extra = O.extraFuel or 2
+  end
+  state.fuel = clamp(state.fuel - (C.Beacon.FuelDrainPerNight + extra), 0, 100)
 	Net.SpawnVFX:FireAllClients({ kind="particle", position = M.GetCFrame().Position })
 	Net.PlaySound:FireAllClients("beacon_on")
 	if state.fuel <= 0 then

--- a/src/ServerScriptService/Services/CosmeticsService.lua
+++ b/src/ServerScriptService/Services/CosmeticsService.lua
@@ -1,0 +1,74 @@
+local Rep = game:GetService("ReplicatedStorage")
+local HttpService = game:GetService("HttpService")
+local Data = require(script.Parent.DataService)
+local Catalog = require(Rep.Shared.Config.Cosmetics)
+
+local M = {}
+
+local function rotationIds(dayIndex: number)
+	-- deterministic daily pick
+	local ids = {}
+	for id, _ in pairs(Catalog.Items) do table.insert(ids, id) end
+	table.sort(ids)
+	local out = {}
+	local n = Catalog.DailyCount or 4
+	for i = 1, #ids do
+		if ((i + dayIndex) % 5) < n then table.insert(out, ids[i]) end
+	end
+	return out
+end
+
+function M.GetShop(player)
+	local day = os.date("*t").yday
+	local picks = rotationIds(day)
+	local snapshot = Data.GetProfileSnapshot(player) or Data.LoadProfileAsync(player)
+	local owned = (snapshot and snapshot.cosmetics) or { outfits={}, campThemes={} }
+	owned.outfits = owned.outfits or {}
+	owned.campThemes = owned.campThemes or {}
+	return {
+		day = day,
+		items = picks,
+		catalog = Catalog.Items,
+		owned = owned,
+		equipped = {
+			camp = snapshot and snapshot.equippedCamp or nil,
+			outfit = snapshot and snapshot.equippedOutfit or nil,
+		}
+	}
+end
+
+function M.Owns(player, id)
+	local prof = Data.GetProfileSnapshot(player) or Data.LoadProfileAsync(player)
+	local it = Catalog.Items[id]; if not it then return false end
+	local bucket = it.type == "camp" and "campThemes" or "outfits"
+	prof.cosmetics = prof.cosmetics or { outfits = {}, campThemes = {} }
+	prof.cosmetics.outfits = prof.cosmetics.outfits or {}
+	prof.cosmetics.campThemes = prof.cosmetics.campThemes or {}
+	for _, v in ipairs(prof.cosmetics[bucket]) do if v == id then return true end end
+	return false
+end
+
+function M.Buy(player, id)
+	local it = Catalog.Items[id]; if not it then return false, "unknown" end
+	if M.Owns(player, id) then return true, "owned" end
+	local prof = Data.GetProfileSnapshot(player) or Data.LoadProfileAsync(player)
+	local cost = it.cost or 10
+	if (prof.currencies.shards or 0) < cost then return false, "not_enough_shards" end
+	prof.currencies.shards -= cost
+	local bucket = it.type == "camp" and "campThemes" or "outfits"
+	prof.cosmetics = prof.cosmetics or { outfits = {}, campThemes = {} }
+	prof.cosmetics.outfits = prof.cosmetics.outfits or {}
+	prof.cosmetics.campThemes = prof.cosmetics.campThemes or {}
+	table.insert(prof.cosmetics[bucket], id)
+	return true, "ok"
+end
+
+function M.Equip(player, id)
+	if not M.Owns(player, id) then return false, "not_owned" end
+	local it = Catalog.Items[id]
+	local prof = Data.GetProfileSnapshot(player) or Data.LoadProfileAsync(player)
+	if it.type == "camp" then prof.equippedCamp = id else prof.equippedOutfit = id end
+	return true, "ok"
+end
+
+return M

--- a/src/ServerScriptService/Services/DataService.lua
+++ b/src/ServerScriptService/Services/DataService.lua
@@ -12,6 +12,9 @@ local TEMPLATE = {
 	cosmetics = { outfits = {}, emotes = {}, campThemes = {} },
 	beaconModsOwned = {},
 	settings = { accessibility = { captions = true, reduceFlashes = true }, input = { stickLayout = "default" } },
+	equippedCamp = nil,
+	equippedOutfit = nil,
+	lastSeenVersion = nil,
 }
 
 local function migrate(p)
@@ -20,6 +23,14 @@ local function migrate(p)
 		-- future fields here
 		p._schema = 1
 	end
+	p.equippedCamp = p.equippedCamp or nil
+	p.equippedOutfit = p.equippedOutfit or nil
+	p.lastSeenVersion = p.lastSeenVersion or nil
+	p.cosmetics = p.cosmetics or { outfits = {}, emotes = {}, campThemes = {} }
+	p.cosmetics.outfits = p.cosmetics.outfits or {}
+	p.cosmetics.campThemes = p.cosmetics.campThemes or {}
+	p.cosmetics.emotes = p.cosmetics.emotes or {}
+	p.currencies = p.currencies or { shards = 0 }
 	return p
 end
 

--- a/src/ServerScriptService/Services/GameService.lua
+++ b/src/ServerScriptService/Services/GameService.lua
@@ -7,6 +7,7 @@ local WavePlanner = require(Rep.Shared.WavePlanner)
 local AISpawner = require(game.ServerScriptService.Services.AISpawnerService)
 local BeaconService = require(game.ServerScriptService.Services.BeaconService)
 local AtmosphereService = require(script.Parent.AtmosphereService)
+local OmenService = require(script.Parent.OmenService)
 
 local M = {}
 local state = { night = 0, phase = "Lobby", omen = nil }
@@ -40,6 +41,7 @@ end
 
 function M.startDay(world)
 	state.phase = "Day"; state.omen = nil
+	OmenService.Clear()
 	local RescueService = require(script.Parent.RescueService)
 	RescueService.GenerateDailyRescues()
 	BeaconService.OnDayStart()
@@ -53,6 +55,7 @@ function M.startNight(world)
 	end
 	state.phase = "Night"; state.night += 1
 	state.omen = rollOmen()
+	OmenService.Set(state.omen)
 	AtmosphereService.OnOmenStart(state.omen)
 	if state.omen then Net.PlaySound:FireAllClients("omen") end
 	BeaconService.OnNightStart()

--- a/src/ServerScriptService/Services/OmenService.lua
+++ b/src/ServerScriptService/Services/OmenService.lua
@@ -1,0 +1,6 @@
+local M = { current = nil }
+function M.Set(omen) M.current = omen end
+function M.Clear() M.current = nil end
+function M.Get() return M.current end
+function M.Is(name) return M.current == name end
+return M

--- a/src/ServerScriptService/Services/PatchNotesService.lua
+++ b/src/ServerScriptService/Services/PatchNotesService.lua
@@ -1,0 +1,14 @@
+local Rep = game:GetService("ReplicatedStorage")
+local Net = require(Rep.Remotes.Net)
+local Notes = require(Rep.Shared.Config.PatchNotes)
+local Data = require(script.Parent.DataService)
+
+local M = {}
+function M.PushIfNew(player)
+	local prof = Data.GetProfileSnapshot(player) or Data.LoadProfileAsync(player)
+	if prof.lastSeenVersion ~= Notes.version then
+		Net.PatchNotesEvt:FireClient(player, Notes)
+		prof.lastSeenVersion = Notes.version
+	end
+end
+return M

--- a/src/StarterPlayer/StarterPlayerScripts/AtmosphereClient.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/AtmosphereClient.client.lua
@@ -14,6 +14,10 @@ local function apply(presetName, omen)
   for k,v in pairs(P.Lighting) do Lighting[k] = v end
   -- Atmosphere
   for k,v in pairs(P.Atmosphere) do atmosphere[k] = v end
+  if omen == "BloodMoon" then
+    atmosphere.Color = Color3.fromRGB(255, 120, 120)
+    atmosphere.Decay = Color3.fromRGB(120, 20, 20)
+  end
   -- Omen adjustments (subtle)
   if omen == "Fog" then atmosphere.Density = atmosphere.Density + 0.15 end
   if omen == "Eclipse" then Lighting.ClockTime = 0; cc.Brightness = cc.Brightness - 0.15 end

--- a/src/StarterPlayer/StarterPlayerScripts/UI/Cosmetics.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/UI/Cosmetics.client.lua
@@ -1,0 +1,42 @@
+local Rep = game:GetService("ReplicatedStorage")
+local Players = game:GetService("Players")
+local Net = require(Rep.Remotes.Net)
+local plr = Players.LocalPlayer
+
+local gui = Instance.new("ScreenGui"); gui.Name="CosmeticsShop"; gui.ResetOnSpawn=false; gui.Parent=plr:WaitForChild("PlayerGui")
+local frame = Instance.new("Frame"); frame.Size=UDim2.new(0,360,0,300); frame.Position=UDim2.new(0,12,0,200); frame.BackgroundTransparency=0.2; frame.Visible=false; frame.Parent=gui
+local lbl = Instance.new("TextLabel"); lbl.Size=UDim2.new(1,0,0,28); lbl.Text="Daily Shop"; lbl.BackgroundTransparency=1; lbl.Font=Enum.Font.GothamBold; lbl.Parent=frame
+local list = Instance.new("Frame"); list.Size=UDim2.new(1,-12,1,-40); list.Position=UDim2.new(0,6,0,36); list.BackgroundTransparency=1; list.Parent=frame
+
+local function clear() for _,c in ipairs(list:GetChildren()) do if c:IsA("TextButton") or c:IsA("TextLabel") then c:Destroy() end end end
+
+local function refresh()
+	clear()
+	local shop = Net.ListCosmetics:InvokeServer()
+	local y = 0
+	for _, id in ipairs(shop.items) do
+		local it = shop.catalog[id]
+		local b = Instance.new("TextButton")
+		b.Size = UDim2.new(1, -12, 0, 32); b.Position = UDim2.new(0,6,0,y); y += 36
+		b.Text = string.format("%s (%s) — %d shards", it.name, it.type, it.cost or 0)
+		b.Parent = list
+		b.MouseButton1Click:Connect(function()
+			local ok, why = Net.BuyCosmetic:InvokeServer(id)
+			if not ok and why ~= "owned" then
+				lbl.Text = "Need shards or not in rotation."
+			else
+				Net.EquipCosmetic:InvokeServer(id)
+				lbl.Text = "Equipped: "..it.name
+			end
+		end)
+	end
+end
+
+-- Toggle button
+local toggle = Instance.new("TextButton")
+toggle.Size=UDim2.new(0,120,0,36); toggle.Position=UDim2.new(0,12,1,-56); toggle.AnchorPoint=Vector2.new(0,1)
+toggle.Text="Cosmetics"; toggle.Parent=gui
+toggle.MouseButton1Click:Connect(function()
+	frame.Visible = not frame.Visible
+	if frame.Visible then refresh() end
+end)

--- a/src/StarterPlayer/StarterPlayerScripts/UI/PatchNotes.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/UI/PatchNotes.client.lua
@@ -1,0 +1,17 @@
+local Rep = game:GetService("ReplicatedStorage")
+local Net = require(Rep.Remotes.Net)
+local Players = game:GetService("Players")
+local plr = Players.LocalPlayer
+
+local gui = Instance.new("ScreenGui"); gui.Name="PatchNotes"; gui.ResetOnSpawn=false; gui.Parent=plr:WaitForChild("PlayerGui")
+local frame = Instance.new("Frame"); frame.Size=UDim2.new(0,420,0,260); frame.Position=UDim2.new(0.5,-210,0.5,-130); frame.BackgroundTransparency=0.15; frame.Visible=false; frame.Parent=gui
+local title = Instance.new("TextLabel"); title.Size=UDim2.new(1,0,0,36); title.Font=Enum.Font.GothamBlack; title.BackgroundTransparency=1; title.Text=""; title.Parent=frame
+local body = Instance.new("TextLabel"); body.Size=UDim2.new(1,-16,1,-60); body.Position=UDim2.new(0,8,0,46); body.BackgroundTransparency=1; body.TextWrapped=true; body.TextYAlignment=Enum.TextYAlignment.Top; body.Font=Enum.Font.Gotham; body.Parent=frame
+local okBtn = Instance.new("TextButton"); okBtn.Size=UDim2.new(0,100,0,28); okBtn.Position=UDim2.new(1,-108,1,-36); okBtn.Text="OK"; okBtn.Parent=frame
+okBtn.MouseButton1Click:Connect(function() frame.Visible=false end)
+
+Net.PatchNotesEvt.OnClientEvent:Connect(function(notes)
+	title.Text = (notes.title or "Update").." v"..tostring(notes.version)
+	body.Text = "- "..table.concat(notes.bullets or {}, "\n- ")
+	frame.Visible = true
+end)

--- a/test/Cosmetics.spec.luau
+++ b/test/Cosmetics.spec.luau
@@ -1,0 +1,9 @@
+return function()
+	local Catalog = require(game.ReplicatedStorage.Shared.Config.Cosmetics)
+	describe("Cosmetics Catalog", function()
+		it("has items and daily count", function()
+			assert(Catalog.Items and next(Catalog.Items) ~= nil, "no items")
+			assert(type(Catalog.DailyCount) == "number", "no daily count")
+		end)
+	end)
+end


### PR DESCRIPTION
Implement the "first update" content pack, introducing the Blood Moon omen, a daily rotation cosmetics shop, and versioned patch notes.

---
<a href="https://cursor.com/background-agent?bcId=bc-3cb54a46-a89e-4061-a714-17aa45f9dff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3cb54a46-a89e-4061-a714-17aa45f9dff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

