### PR TITLE
Add codex prompt system and onboarding UI

### DIFF
--- a/src/ReplicatedStorage/Shared/Codex/Prompts.lua
+++ b/src/ReplicatedStorage/Shared/Codex/Prompts.lua
@@ -1,0 +1,187 @@
+local Prompts = {
+    {
+        id = "intro_campfire",
+        title = "Build Your First Campfire",
+        body = "codex.build.campfire.body",
+        icon = "rbxassetid://0",
+        category = "Basics",
+        priority = 100,
+        oncePerProfile = true,
+        cooldownSec = 120,
+        triggers = { "DAY_START" },
+        gates = {
+            { type = "DayAtLeast", value = 1 },
+            { type = "StructureCountBelow", struct = "Campfire", value = 1 },
+            { type = "NearBeacon", meters = 60 },
+        },
+        actions = {
+            { label = "Open Build", event = "OPEN_BUILD_MENU" },
+            { label = "Pin Objective", event = "PIN_OBJECTIVE", payload = { id = "build_campfire" } },
+        },
+    },
+    {
+        id = "beacon_fuel",
+        title = "Keep the Beacon Burning",
+        body = "codex.beacon.fuel.body",
+        icon = "rbxassetid://0",
+        category = "Basics",
+        priority = 90,
+        oncePerProfile = false,
+        cooldownSec = 180,
+        triggers = { "NIGHT_START", "BEACON_FUEL_LOW" },
+        gates = {
+            { type = "BeaconFuelBelow", value = 60 },
+            { type = "OncePerSession" },
+        },
+        actions = {
+            { label = "Add Fuel", event = "OPEN_BEACON" },
+        },
+    },
+    {
+        id = "beacon_milestone",
+        title = "Beacon Boost Achieved",
+        body = "codex.beacon.upgrade.body",
+        icon = "rbxassetid://0",
+        category = "Milestones",
+        priority = 85,
+        oncePerProfile = false,
+        cooldownSec = 300,
+        triggers = { "BEACON_FUEL_MILESTONE" },
+        gates = {
+            { type = "OncePerSession" },
+        },
+        actions = {
+            { label = "Celebrate", event = "EMOTE", payload = { id = "cheer" } },
+        },
+    },
+    {
+        id = "rescue_multiplier",
+        title = "Rescue to Accelerate Days",
+        body = "codex.rescue.multiplier.body",
+        icon = "rbxassetid://0",
+        category = "Milestones",
+        priority = 92,
+        oncePerProfile = false,
+        cooldownSec = 0,
+        triggers = { "RESCUE_COMPLETE" },
+        gates = {
+            { type = "OncePerSession" },
+        },
+        actions = {
+            { label = "Plan Next Rescue", event = "OPEN_MAP" },
+        },
+    },
+    {
+        id = "build_watchtower",
+        title = "Claim High Ground",
+        body = "codex.build.watchtower.body",
+        icon = "rbxassetid://0",
+        category = "Basics",
+        priority = 70,
+        oncePerProfile = true,
+        cooldownSec = 240,
+        triggers = { "STRUCTURE_PLACED" },
+        gates = {
+            { type = "PayloadEquals", key = "structure", value = "Wall" },
+            { type = "StructureCountBelow", struct = "Watchtower", value = 1 },
+        },
+        actions = {
+            { label = "Queue Watchtower", event = "OPEN_BUILD_MENU", payload = { focus = "Watchtower" } },
+        },
+    },
+    {
+        id = "trap_basics",
+        title = "Layer Your Traps",
+        body = "codex.build.traps.body",
+        icon = "rbxassetid://0",
+        category = "Basics",
+        priority = 68,
+        oncePerProfile = true,
+        cooldownSec = 240,
+        triggers = { "STRUCTURE_PLACED" },
+        gates = {
+            { type = "StructureCountAtLeast", struct = "Wall", value = 2 },
+            { type = "StructureCountBelow", struct = "TrapSpike", value = 1 },
+        },
+        actions = {
+            { label = "Place Trap", event = "OPEN_BUILD_MENU", payload = { focus = "TrapSpike" } },
+        },
+    },
+    {
+        id = "omen_alert",
+        title = "Blood Moon Incoming",
+        body = "codex.omen.bloodmoon.body",
+        icon = "rbxassetid://0",
+        category = "Omens",
+        priority = 95,
+        oncePerProfile = false,
+        cooldownSec = 0,
+        triggers = { "OMEN_BEGIN" },
+        gates = {
+            { type = "PayloadEquals", key = "omen", value = "BloodMoon" },
+            { type = "OncePerSession" },
+        },
+    },
+    {
+        id = "shop_intro",
+        title = "Visit the Camp Shop",
+        body = "codex.economy.shop.body",
+        icon = "rbxassetid://0",
+        category = "Economy",
+        priority = 60,
+        oncePerProfile = true,
+        cooldownSec = 0,
+        triggers = { "NIGHT_END" },
+        gates = {
+            { type = "DayAtLeast", value = 1 },
+        },
+        actions = {
+            { label = "Open Shop", event = "OPEN_SHOP" },
+        },
+    },
+    {
+        id = "accessibility_settings",
+        title = "Tune Accessibility",
+        body = "codex.accessibility.settings.body",
+        icon = "rbxassetid://0",
+        category = "Basics",
+        priority = 88,
+        oncePerProfile = true,
+        cooldownSec = 0,
+        triggers = { "PLAYER_JOINED" },
+        gates = {
+            { type = "ProfileSettingEquals", category = "accessibility", key = "reduceFlashes", value = false },
+        },
+        actions = {
+            { label = "Open Settings", event = "OPEN_SETTINGS", payload = { tab = "Accessibility" } },
+        },
+    },
+    {
+        id = "photo_helper",
+        title = "Capture the Run",
+        body = "codex.photo.helper.body",
+        icon = "rbxassetid://0",
+        category = "Extras",
+        priority = 40,
+        oncePerProfile = false,
+        cooldownSec = 600,
+        triggers = { "DAY_START" },
+        gates = {
+            { type = "DayAtLeast", value = 3 },
+            { type = "OncePerSession" },
+        },
+        actions = {
+            { label = "Open Photo Helper", event = "OPEN_PHOTO_HELPER" },
+        },
+    },
+}
+
+for _, prompt in ipairs(Prompts) do
+    prompt.priority = prompt.priority or 0
+end
+
+table.sort(Prompts, function(a, b)
+    return (a.priority or 0) > (b.priority or 0)
+end)
+
+return Prompts

--- a/src/ReplicatedStorage/Shared/Localization/en.lua
+++ b/src/ReplicatedStorage/Shared/Localization/en.lua
@@ -1,0 +1,48 @@
+return {
+    codex = {
+        build = {
+            campfire = {
+                body = "Gather sticks and use the Build menu to place a campfire near the beacon. It keeps the squad warm and unlocks more crafting.";
+            };
+            watchtower = {
+                body = "Raise a watchtower once you have a few walls down. High ground reveals approaching threats early.";
+            };
+            traps = {
+                body = "Spike traps slow the swarm and stack with barricades. Drop them in front of your walls before nightfall.";
+            };
+        };
+        beacon = {
+            fuel = {
+                body = "Keep the beacon fueled above 60% to lower nightly pressure and extend safe daylight.";
+            };
+            upgrade = {
+                body = "Every 100 fuel boosts the day multiplier. Coordinate refuels to accelerate through the 99 nights.";
+            };
+        };
+        rescue = {
+            multiplier = {
+                body = "Escorting survivors back to camp adds +0.10 to the day multiplier. More rescues mean faster dawns.";
+            };
+        };
+        omen = {
+            bloodmoon = {
+                body = "Blood Moon omens spike enemy spawns. Stick together, watch your traps, and refuel between waves.";
+            };
+        };
+        economy = {
+            shop = {
+                body = "Spend shards on cosmetics between nights. New drops rotate in, so check the shop often.";
+            };
+        };
+        accessibility = {
+            settings = {
+                body = "Toggle accessibility settings anytime to enable captions or reduce bright flashes for the squad.";
+            };
+        };
+        photo = {
+            helper = {
+                body = "Use the Photo Helper to snap clean shots of your camp for thumbnails and squad memories.";
+            };
+        };
+    };
+}

--- a/src/ReplicatedStorage/Shared/Localization/init.lua
+++ b/src/ReplicatedStorage/Shared/Localization/init.lua
@@ -1,0 +1,33 @@
+local Localization = {}
+local defaultLocale = require(script.en)
+
+local function resolveKey(tbl, key)
+    local current = tbl
+    for _, part in ipairs(string.split(key, ".")) do
+        if typeof(current) ~= "table" then
+            return nil
+        end
+        current = current[part]
+    end
+    return current
+end
+
+function Localization.get(key)
+    if typeof(key) ~= "string" then
+        return key
+    end
+    local value = resolveKey(defaultLocale, key)
+    if value == nil then
+        return key
+    end
+    if typeof(value) == "string" then
+        return value
+    end
+    return key
+end
+
+function Localization.getDictionary()
+    return defaultLocale
+end
+
+return Localization

--- a/src/ServerScriptService/Server/Server.main.server.lua
+++ b/src/ServerScriptService/Server/Server.main.server.lua
@@ -32,13 +32,29 @@ local DataService = require(ServicesFolder.DataService)
 local BeaconService = require(ServicesFolder.BeaconService)
 local TutorialService = require(ServicesFolder.TutorialService)
 local PatchNotes = require(ServicesFolder.PatchNotesService)
+local CodexService = require(ServicesFolder.CodexService)
 
 game.Players.PlayerAdded:Connect(function(plr)
-	DataService.LoadProfileAsync(plr)
-	TutorialService.Begin(plr)
-	PatchNotes.PushIfNew(plr)
+        DataService.LoadProfileAsync(plr)
+        TutorialService.Begin(plr)
+        PatchNotes.PushIfNew(plr)
+        CodexService.OnPlayerAdded(plr)
 end)
-game.Players.PlayerRemoving:Connect(function(plr) DataService.SaveProfileAsync(plr) end)
+game.Players.PlayerRemoving:Connect(function(plr)
+        CodexService.OnPlayerRemoving(plr)
+        DataService.SaveProfileAsync(plr)
+end)
+
+CodexService.UpdateWorldState({
+        day = 1,
+        phase = "Day",
+        camp = {
+                beaconFuel = BeaconService.GetState().fuel,
+                position = BeaconService.GetCFrame().Position,
+                structures = {},
+        },
+        omen = nil,
+})
 
 GameService.start(World)
 

--- a/src/ServerScriptService/Services/BeaconService.lua
+++ b/src/ServerScriptService/Services/BeaconService.lua
@@ -3,27 +3,46 @@ local Net = require(Rep.Remotes.Net)
 local C = require(Rep.Shared.Constants)
 local Tuning = require(Rep.Shared.Config.Tuning)
 local OmenService = require(script.Parent.OmenService)
+local CodexService = require(script.Parent.CodexService)
 
 local M = {}
 local state = { fuel = 100, heat = 100, lightRadius = 90, stability = 1, mods = {} }
 local function clamp(x, a, b) return math.max(a, math.min(b, x)) end
 local function fire() Net.BeaconChanged:FireAllClients(table.freeze(table.clone(state))) end
+local lastFuelMilestone = nil
 
 -- world beacon instance (simple Part if none)
 local function ensureBeacon()
 	local b = workspace:FindFirstChild("Beacon")
-	if not b then
-		b = Instance.new("Part")
-		b.Name = "Beacon"; b.Anchored = true; b.CanCollide = false; b.Size = Vector3.new(4,8,4)
-		b.Position = Vector3.new(0,4,0); b.Material = Enum.Material.Neon
-		b.Color = Color3.fromRGB(255, 214, 120); b.Parent = workspace
-	end
-	return b
+        if not b then
+                b = Instance.new("Part")
+                b.Name = "Beacon"; b.Anchored = true; b.CanCollide = false; b.Size = Vector3.new(4,8,4)
+                b.Position = Vector3.new(0,4,0); b.Material = Enum.Material.Neon
+                b.Color = Color3.fromRGB(255, 214, 120); b.Parent = workspace
+        end
+        CodexService.UpdateWorldState({ camp = { position = b.Position } })
+        return b
 end
 
 function M.GetCFrame() return ensureBeacon().CFrame end
 function M.GetState() return state end
-function M.ApplyFuel(n) state.fuel = clamp(state.fuel + (n or 0), 0, 100); fire(); return state.fuel end
+function M.ApplyFuel(n)
+        state.fuel = clamp(state.fuel + (n or 0), 0, 100)
+        CodexService.UpdateWorldState({ camp = { beaconFuel = state.fuel } })
+        if state.fuel < 60 then
+                CodexService.Emit("BEACON_FUEL_LOW", { fuel = state.fuel })
+        end
+        if state.fuel >= 95 then
+                if lastFuelMilestone ~= 100 then
+                        lastFuelMilestone = 100
+                        CodexService.Emit("BEACON_FUEL_MILESTONE", { fuel = state.fuel })
+                end
+        else
+                lastFuelMilestone = nil
+        end
+        fire()
+        return state.fuel
+end
 
 local modHandlers = {
 	RadiusPlus = function(en) state.lightRadius = en and 110 or 90 end,
@@ -47,8 +66,9 @@ end
 
 -- Day/Night hooks
 function M.OnDayStart()
-	state.heat = clamp(state.heat + C.Beacon.HeatRecoveryPerDay, 0, 100)
-	fire()
+        state.heat = clamp(state.heat + C.Beacon.HeatRecoveryPerDay, 0, 100)
+        CodexService.UpdateWorldState({ camp = { beaconFuel = state.fuel } })
+        fire()
 end
 
 function M.OnNightStart()
@@ -58,14 +78,15 @@ function M.OnNightStart()
     extra = O.extraFuel or 2
   end
   state.fuel = clamp(state.fuel - (C.Beacon.FuelDrainPerNight + extra), 0, 100)
-	Net.SpawnVFX:FireAllClients({ kind="particle", position = M.GetCFrame().Position })
-	Net.PlaySound:FireAllClients("beacon_on")
-	if state.fuel <= 0 then
-		Net.PlaySound:FireAllClients("beacon_off")
-		warn("[Beacon] Blackout!")
-		Net.BroadcastState:FireAllClients({ blackout = true })
-	end
-	fire()
+        Net.SpawnVFX:FireAllClients({ kind="particle", position = M.GetCFrame().Position })
+        Net.PlaySound:FireAllClients("beacon_on")
+        if state.fuel <= 0 then
+                Net.PlaySound:FireAllClients("beacon_off")
+                warn("[Beacon] Blackout!")
+                Net.BroadcastState:FireAllClients({ blackout = true })
+        end
+        CodexService.UpdateWorldState({ camp = { beaconFuel = state.fuel } })
+        fire()
 end
 
 return M

--- a/src/ServerScriptService/Services/BuildService.lua
+++ b/src/ServerScriptService/Services/BuildService.lua
@@ -14,6 +14,7 @@ local InstanceRef = require(Rep.Components.C_InstanceRef)
 local Trap = require(Rep.Components.C_Trap)
 
 local Net = require(Rep.Remotes.Net)
+local CodexService = require(script.Parent.CodexService)
 
 local M = {}
 local GRID = 2
@@ -88,11 +89,11 @@ function M.Place(player, placeType, cf)
 	local counts = placedCounts[player.UserId]; counts[placeType] = (counts[placeType] or 0) + 1
 	globalCount += 1
 
-	local p = createStructureInstance(placeType, snapped)
-	local world = WorldRegistry.get()
-	if world then
-		local comps = {
-			Buildable({ owner = player.UserId, type = placeType }),
+        local p = createStructureInstance(placeType, snapped)
+        local world = WorldRegistry.get()
+        if world then
+                local comps = {
+                        Buildable({ owner = player.UserId, type = placeType }),
 			Health({ hp = p:GetAttribute("HP"), max = p:GetAttribute("HP") }),
 			InstanceRef({ inst = p }),
 		}
@@ -101,13 +102,16 @@ function M.Place(player, placeType, cf)
 		elseif placeType == "SlowTotem" then
 			table.insert(comps, Trap({ kind = "Slow", cooldown = 0 }))
 		end
-		world:spawn(table.unpack(comps))
-	end
+                world:spawn(table.unpack(comps))
+        end
 
-	-- Tutorial hook (non-fatal)
-	pcall(function()
-		require(script.Parent.TutorialService).OnAction(player, "place")
-	end)
+        CodexService.RecordStructurePlacement(placeType)
+        CodexService.Emit("STRUCTURE_PLACED", { player = player, playerUserId = player.UserId, structure = placeType })
+
+        -- Tutorial hook (non-fatal)
+        pcall(function()
+                require(script.Parent.TutorialService).OnAction(player, "place")
+        end)
 
 	return p:GetDebugId()
 end

--- a/src/ServerScriptService/Services/CodexService.lua
+++ b/src/ServerScriptService/Services/CodexService.lua
@@ -1,0 +1,396 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Analytics = require(script.Parent.AnalyticsAdapter)
+local DataService = require(script.Parent.DataService)
+local Net = require(ReplicatedStorage.Remotes.Net)
+local Prompts = require(ReplicatedStorage.Shared.Codex.Prompts)
+
+local CodexService = {}
+
+local worldState = {
+    day = 1,
+    phase = "Day",
+    camp = {
+        beaconFuel = 100,
+        structures = {},
+        position = Vector3.new(),
+    },
+    omen = nil,
+}
+
+local sessionState = {} -- [userId] = { shown = {}, cooldowns = {}, active = {} }
+local pendingReplay = {} -- [userId] = { [promptId] = { prompt = promptPayload } }
+local initialized = false
+
+local function ensureInit()
+    if initialized then
+        return
+    end
+    initialized = true
+
+    Net.TutorialEvent.OnServerEvent:Connect(function(player, payload)
+        if typeof(payload) ~= "table" then
+            return
+        end
+        local kind = payload.t
+        if kind == "CODEX_ACK" then
+            local promptId = payload.id
+            if typeof(promptId) ~= "string" then
+                return
+            end
+            local session = sessionState[player.UserId]
+            if session and session.active then
+                session.active[promptId] = nil
+            end
+            if pendingReplay[player.UserId] then
+                pendingReplay[player.UserId][promptId] = nil
+            end
+            DataService.MarkCodexCompleted(player, promptId)
+            Analytics.Custom("codex_ack", {
+                u = player.UserId,
+                id = promptId,
+                day = worldState.day,
+                phase = worldState.phase,
+            })
+        elseif kind == "CODEX_ACTION" then
+            local promptId = payload.id
+            local action = payload.action
+            if typeof(promptId) ~= "string" or typeof(action) ~= "string" then
+                return
+            end
+            Analytics.Custom("codex_clicked", {
+                u = player.UserId,
+                id = promptId,
+                action = action,
+            })
+        elseif kind == "CODEX_PIN" then
+            local promptId = payload.id
+            if typeof(promptId) ~= "string" then
+                return
+            end
+            Analytics.Custom("codex_pinned", {
+                u = player.UserId,
+                id = promptId,
+            })
+        end
+    end)
+end
+
+local function ensureSession(player)
+    local session = sessionState[player.UserId]
+    if session then
+        return session
+    end
+    session = {
+        shown = {},
+        cooldowns = {},
+        active = {},
+    }
+    sessionState[player.UserId] = session
+    return session
+end
+
+local function cloneActions(actions)
+    if typeof(actions) ~= "table" then
+        return nil
+    end
+    local list = {}
+    for _, action in ipairs(actions) do
+        local entry = {
+            label = action.label,
+            event = action.event,
+        }
+        if action.payload ~= nil then
+            entry.payload = table.clone(action.payload)
+        end
+        table.insert(list, entry)
+    end
+    return list
+end
+
+local function buildPromptPayload(prompt)
+    return {
+        id = prompt.id,
+        title = prompt.title,
+        body = prompt.body,
+        icon = prompt.icon,
+        category = prompt.category,
+        priority = prompt.priority,
+        actions = cloneActions(prompt.actions),
+    }
+end
+
+local function getProfile(player)
+    local profile = DataService.GetProfileSnapshot(player)
+    if not profile then
+        profile = DataService.LoadProfileAsync(player)
+    end
+    return profile
+end
+
+local function merge(target, source)
+    for key, value in pairs(source) do
+        if typeof(value) == "table" then
+            if typeof(target[key]) ~= "table" then
+                target[key] = {}
+            end
+            merge(target[key], value)
+        else
+            target[key] = value
+        end
+    end
+end
+
+local function resolveTargets(payload)
+    local targeted = false
+    if typeof(payload) == "table" then
+        if payload.player then
+            targeted = true
+            if typeof(payload.player) == "Instance" then
+                return { payload.player }
+            elseif typeof(payload.player) == "number" then
+                local plr = Players:GetPlayerByUserId(payload.player)
+                if plr then
+                    return { plr }
+                end
+            end
+        end
+        if payload.playerUserId then
+            targeted = true
+            local plr = Players:GetPlayerByUserId(payload.playerUserId)
+            if plr then
+                return { plr }
+            end
+        end
+        if payload.players then
+            targeted = true
+            local list = {}
+            for _, item in ipairs(payload.players) do
+                if typeof(item) == "Instance" then
+                    table.insert(list, item)
+                elseif typeof(item) == "number" then
+                    local plr = Players:GetPlayerByUserId(item)
+                    if plr then
+                        table.insert(list, plr)
+                    end
+                end
+            end
+            if #list > 0 then
+                return list
+            end
+        end
+    end
+    if targeted then
+        return {}
+    end
+    return Players:GetPlayers()
+end
+
+local Gates = {}
+
+function Gates.DayAtLeast(ctx, gate)
+    return (ctx.world.day or 1) >= (gate.value or gate.min or 0)
+end
+
+function Gates.StructureCountBelow(ctx, gate)
+    local count = ctx.world.camp.structures[gate.struct] or 0
+    return count < (gate.value or 0)
+end
+
+function Gates.StructureCountAtLeast(ctx, gate)
+    local count = ctx.world.camp.structures[gate.struct] or 0
+    return count >= (gate.value or 0)
+end
+
+function Gates.NearBeacon(ctx, gate)
+    local char = ctx.player.Character
+    if not char or not char.PrimaryPart then
+        return true
+    end
+    local beaconPos = ctx.world.camp.position or Vector3.new()
+    local meters = gate.meters or 30
+    return (char.PrimaryPart.Position - beaconPos).Magnitude <= meters
+end
+
+function Gates.OncePerSession(ctx)
+    return not ctx.session.shown[ctx.prompt.id]
+end
+
+function Gates.BeaconFuelBelow(ctx, gate)
+    local fuel = ctx.world.camp.beaconFuel or 0
+    return fuel < (gate.value or 0)
+end
+
+function Gates.PayloadEquals(ctx, gate)
+    if typeof(ctx.payload) ~= "table" then
+        return false
+    end
+    return ctx.payload[gate.key] == gate.value
+end
+
+function Gates.ProfileSettingEquals(ctx, gate)
+    local profile = ctx.profile
+    if not profile or not profile.settings then
+        return false
+    end
+    local category = gate.category
+    local key = gate.key
+    if typeof(profile.settings[category]) ~= "table" then
+        return false
+    end
+    return profile.settings[category][key] == gate.value
+end
+
+local function evaluateGate(ctx, gate)
+    local handler = Gates[gate.type]
+    if not handler then
+        return false
+    end
+    return handler(ctx, gate)
+end
+
+local function canShowPrompt(ctx, prompt)
+    if ctx.session.active[prompt.id] then
+        return false
+    end
+    local cooldownUntil = ctx.session.cooldowns[prompt.id]
+    if cooldownUntil and cooldownUntil > os.clock() then
+        return false
+    end
+    local profile = ctx.profile
+    if prompt.oncePerProfile then
+        local seen = profile and profile.codex and profile.codex.seen
+        if seen and seen[prompt.id] then
+            return false
+        end
+    end
+    if prompt.gates then
+        for _, gate in ipairs(prompt.gates) do
+            if not evaluateGate(ctx, gate) then
+                return false
+            end
+        end
+    end
+    return true
+end
+
+local function showPrompt(player, ctx, prompt)
+    local payload = buildPromptPayload(prompt)
+    ctx.session.shown[prompt.id] = true
+    ctx.session.cooldowns[prompt.id] = os.clock() + (prompt.cooldownSec or 0)
+    ctx.session.active[prompt.id] = { prompt = payload }
+    pendingReplay[player.UserId] = pendingReplay[player.UserId] or {}
+    pendingReplay[player.UserId][prompt.id] = { prompt = payload }
+    DataService.MarkCodexSeen(player, prompt.id)
+    Net.TutorialEvent:FireClient(player, {
+        t = "SHOW_CODEX",
+        prompt = payload,
+    })
+    Analytics.Custom("codex_shown", {
+        u = player.UserId,
+        id = prompt.id,
+        trigger = ctx.trigger,
+        day = worldState.day,
+        fuel = worldState.camp.beaconFuel,
+        omen = worldState.omen,
+    })
+end
+
+function CodexService.Emit(trigger, payload)
+    ensureInit()
+    for _, player in ipairs(resolveTargets(payload)) do
+        local profile = getProfile(player)
+        if profile then
+            profile.codex = profile.codex or { seen = {}, completed = {} }
+            profile.codex.seen = profile.codex.seen or {}
+            profile.codex.completed = profile.codex.completed or {}
+        end
+        local session = ensureSession(player)
+        local ctx = {
+            player = player,
+            profile = profile,
+            session = session,
+            world = worldState,
+            payload = payload,
+            trigger = trigger,
+        }
+        for _, prompt in ipairs(Prompts) do
+            if table.find(prompt.triggers, trigger) then
+                ctx.prompt = prompt
+                if canShowPrompt(ctx, prompt) then
+                    showPrompt(player, ctx, prompt)
+                end
+            end
+        end
+    end
+end
+
+function CodexService.UpdateWorldState(partial)
+    merge(worldState, partial)
+end
+
+function CodexService.RecordStructurePlacement(structType)
+    structType = tostring(structType)
+    worldState.camp.structures[structType] = (worldState.camp.structures[structType] or 0) + 1
+end
+
+function CodexService.ResetCampStructures()
+    worldState.camp.structures = {}
+end
+
+function CodexService.OnPlayerAdded(player)
+    ensureInit()
+    local session = ensureSession(player)
+    session.shown = {}
+    session.cooldowns = {}
+    session.active = pendingReplay[player.UserId] or {}
+    for promptId in pairs(session.active) do
+        session.shown[promptId] = true
+    end
+    pendingReplay[player.UserId] = nil
+
+    local profile = getProfile(player)
+    local statePayload = {
+        seen = {},
+        completed = {},
+    }
+    if profile and profile.codex then
+        statePayload.seen = table.clone(profile.codex.seen or {})
+        statePayload.completed = table.clone(profile.codex.completed or {})
+    end
+    Net.TutorialEvent:FireClient(player, {
+        t = "SYNC_CODEX",
+        state = statePayload,
+    })
+
+    for _, entry in pairs(session.active) do
+        if entry.prompt then
+            Net.TutorialEvent:FireClient(player, {
+                t = "SHOW_CODEX",
+                prompt = entry.prompt,
+            })
+        end
+    end
+
+    CodexService.Emit("PLAYER_JOINED", { player = player })
+end
+
+function CodexService.OnPlayerRemoving(player)
+    local session = sessionState[player.UserId]
+    if not session then
+        return
+    end
+    pendingReplay[player.UserId] = {}
+    for promptId, entry in pairs(session.active) do
+        pendingReplay[player.UserId][promptId] = entry
+    end
+    sessionState[player.UserId] = nil
+end
+
+CodexService._test = {
+    evaluateGate = evaluateGate,
+    canShow = canShowPrompt,
+}
+
+return CodexService

--- a/src/ServerScriptService/Services/DataService.lua
+++ b/src/ServerScriptService/Services/DataService.lua
@@ -4,17 +4,18 @@ local ProfileStore = require(script.Parent.ProfileStore)
 local profiles = {}
 local SCHEMA = 1
 local TEMPLATE = {
-	_schema = SCHEMA,
-	bestNight = 0,
-	totalRescues = 0,
-	currencies = { shards = 0 },
-	talents = {},
-	cosmetics = { outfits = {}, emotes = {}, campThemes = {} },
-	beaconModsOwned = {},
-	settings = { accessibility = { captions = true, reduceFlashes = true }, input = { stickLayout = "default" } },
-	equippedCamp = nil,
-	equippedOutfit = nil,
-	lastSeenVersion = nil,
+        _schema = SCHEMA,
+        bestNight = 0,
+        totalRescues = 0,
+        currencies = { shards = 0 },
+        talents = {},
+        cosmetics = { outfits = {}, emotes = {}, campThemes = {} },
+        beaconModsOwned = {},
+        settings = { accessibility = { captions = true, reduceFlashes = true }, input = { stickLayout = "default" } },
+        equippedCamp = nil,
+        equippedOutfit = nil,
+        lastSeenVersion = nil,
+        codex = { seen = {}, completed = {} },
 }
 
 local function migrate(p)
@@ -27,11 +28,14 @@ local function migrate(p)
 	p.equippedOutfit = p.equippedOutfit or nil
 	p.lastSeenVersion = p.lastSeenVersion or nil
 	p.cosmetics = p.cosmetics or { outfits = {}, emotes = {}, campThemes = {} }
-	p.cosmetics.outfits = p.cosmetics.outfits or {}
-	p.cosmetics.campThemes = p.cosmetics.campThemes or {}
-	p.cosmetics.emotes = p.cosmetics.emotes or {}
-	p.currencies = p.currencies or { shards = 0 }
-	return p
+        p.cosmetics.outfits = p.cosmetics.outfits or {}
+        p.cosmetics.campThemes = p.cosmetics.campThemes or {}
+        p.cosmetics.emotes = p.cosmetics.emotes or {}
+        p.currencies = p.currencies or { shards = 0 }
+        p.codex = p.codex or { seen = {}, completed = {} }
+        p.codex.seen = p.codex.seen or {}
+        p.codex.completed = p.codex.completed or {}
+        return p
 end
 
 local M = {}
@@ -67,7 +71,27 @@ function M.GrantBlueprintOrToken(userId)
 end
 
 function M.GetProfileSnapshot(player)
-	return profiles[player.UserId]
+        return profiles[player.UserId]
+end
+
+local function ensureCodex(player)
+        local profile = profiles[player.UserId] or M.LoadProfileAsync(player)
+        profile.codex = profile.codex or { seen = {}, completed = {} }
+        profile.codex.seen = profile.codex.seen or {}
+        profile.codex.completed = profile.codex.completed or {}
+        return profile
+end
+
+function M.MarkCodexSeen(player, promptId)
+        if not promptId then return end
+        local profile = ensureCodex(player)
+        profile.codex.seen[promptId] = true
+end
+
+function M.MarkCodexCompleted(player, promptId)
+        if not promptId then return end
+        local profile = ensureCodex(player)
+        profile.codex.completed[promptId] = true
 end
 
 return M

--- a/src/ServerScriptService/Services/OmenService.lua
+++ b/src/ServerScriptService/Services/OmenService.lua
@@ -1,6 +1,20 @@
+local CodexService = require(script.Parent.CodexService)
+
 local M = { current = nil }
-function M.Set(omen) M.current = omen end
-function M.Clear() M.current = nil end
+function M.Set(omen)
+        M.current = omen
+        CodexService.UpdateWorldState({ omen = omen })
+        if omen then
+                CodexService.Emit("OMEN_BEGIN", { omen = omen })
+        end
+end
+function M.Clear()
+        if M.current then
+                CodexService.Emit("OMEN_CLEAR", { omen = M.current })
+        end
+        M.current = nil
+        CodexService.UpdateWorldState({ omen = nil })
+end
 function M.Get() return M.current end
 function M.Is(name) return M.current == name end
 return M

--- a/src/ServerScriptService/Services/RescueService.lua
+++ b/src/ServerScriptService/Services/RescueService.lua
@@ -3,6 +3,7 @@ local Players = game:GetService("Players")
 local BeaconService = require(script.Parent.BeaconService)
 local Net = require(Rep.Remotes.Net)
 local DataService = require(script.Parent.DataService)
+local CodexService = require(script.Parent.CodexService)
 
 local M = {}
 local activeRescue = nil
@@ -51,10 +52,16 @@ game:GetService("RunService").Stepped:Connect(function()
 			activeRescue.inst.AssemblyLinearVelocity = Vector3.new(v.X, activeRescue.inst.AssemblyLinearVelocity.Y, v.Z)
 		else
 			-- Arrived!
-			DataService.GrantBlueprintOrToken(activeRescue.escorter)
-			if activeRescue.inst.Parent then activeRescue.inst:Destroy() end
-			activeRescue = nil
-			Net.BroadcastState:FireAllClients({ rescue = "complete" })
+                        DataService.GrantBlueprintOrToken(activeRescue.escorter)
+                        local escorterPlayer = Players:GetPlayerByUserId(activeRescue.escorter)
+                        CodexService.Emit("RESCUE_COMPLETE", {
+                                player = escorterPlayer,
+                                playerUserId = activeRescue.escorter,
+                                escorter = activeRescue.escorter,
+                        })
+                        if activeRescue.inst.Parent then activeRescue.inst:Destroy() end
+                        activeRescue = nil
+                        Net.BroadcastState:FireAllClients({ rescue = "complete" })
 		end
 	end
 end)

--- a/src/StarterPlayer/StarterPlayerScripts/CodexUI.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/CodexUI.client.lua
@@ -1,0 +1,270 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local TweenService = game:GetService("TweenService")
+
+local player = Players.LocalPlayer
+local Net = require(ReplicatedStorage.Remotes.Net)
+local Localization = require(ReplicatedStorage.Shared.Localization)
+
+local gui = Instance.new("ScreenGui")
+gui.Name = "Codex"
+gui.ResetOnSpawn = false
+gui.Parent = player:WaitForChild("PlayerGui")
+
+local panel = Instance.new("Frame")
+panel.Name = "Panel"
+panel.AnchorPoint = Vector2.new(1, 0)
+panel.Position = UDim2.new(1, -24, 0.2, 0)
+panel.Size = UDim2.new(0, 320, 0.6, 0)
+panel.BackgroundTransparency = 0.35
+panel.BackgroundColor3 = Color3.fromRGB(20, 20, 20)
+panel.Parent = gui
+
+local panelPadding = Instance.new("UIPadding")
+panelPadding.PaddingTop = UDim.new(0, 12)
+panelPadding.PaddingBottom = UDim.new(0, 12)
+panelPadding.PaddingLeft = UDim.new(0, 12)
+panelPadding.PaddingRight = UDim.new(0, 12)
+panelPadding.Parent = panel
+
+local list = Instance.new("UIListLayout")
+list.Padding = UDim.new(0, 8)
+list.SortOrder = Enum.SortOrder.LayoutOrder
+list.Parent = panel
+
+local toastFrame = Instance.new("Frame")
+toastFrame.Name = "Toast"
+toastFrame.AnchorPoint = Vector2.new(0.5, 1)
+toastFrame.Position = UDim2.new(0.5, 0, 1, -24)
+toastFrame.Size = UDim2.new(0, 360, 0, 48)
+toastFrame.BackgroundColor3 = Color3.fromRGB(25, 25, 25)
+toastFrame.BackgroundTransparency = 0.2
+toastFrame.Visible = false
+toastFrame.Parent = gui
+
+local toastLabel = Instance.new("TextLabel")
+toastLabel.Size = UDim2.new(1, -12, 1, -12)
+toastLabel.Position = UDim2.new(0, 6, 0, 6)
+toastLabel.BackgroundTransparency = 1
+toastLabel.TextColor3 = Color3.new(1, 1, 1)
+toastLabel.TextSize = 18
+toastLabel.Font = Enum.Font.GothamBold
+toastLabel.TextWrapped = true
+toastLabel.Parent = toastFrame
+
+local activePrompts = {}
+local seenState = {}
+local completedState = {}
+local toastToken = 0
+
+local function showToast(message)
+    toastToken += 1
+    local token = toastToken
+    toastLabel.Text = message
+    toastFrame.Visible = true
+    toastFrame.BackgroundTransparency = 0.2
+    task.spawn(function()
+        task.wait(3)
+        if toastToken == token then
+            local tween = TweenService:Create(toastFrame, TweenInfo.new(0.25), { BackgroundTransparency = 1 })
+            tween:Play()
+            tween.Completed:Wait()
+            if toastToken == token then
+                toastFrame.Visible = false
+            end
+        end
+    end)
+end
+
+local function resolveBody(bodyKey)
+    return Localization.get(bodyKey)
+end
+
+local function sendAck(promptId)
+    Net.TutorialEvent:FireServer({
+        t = "CODEX_ACK",
+        id = promptId,
+    })
+end
+
+local function sendAction(promptId, action)
+    if typeof(action.event) ~= "string" then
+        return
+    end
+    Net.TutorialEvent:FireServer({
+        t = "CODEX_ACTION",
+        id = promptId,
+        action = action.event,
+        payload = action.payload,
+    })
+end
+
+local function updateStatusLabel(label, promptId)
+    if completedState[promptId] then
+        label.Text = "Completed"
+        label.TextColor3 = Color3.fromRGB(120, 255, 180)
+    elseif seenState[promptId] then
+        label.Text = "Seen"
+        label.TextColor3 = Color3.fromRGB(200, 200, 200)
+    else
+        label.Text = ""
+    end
+end
+
+local function removePrompt(promptId)
+    local entry = activePrompts[promptId]
+    if not entry then
+        return
+    end
+    activePrompts[promptId] = nil
+    entry.frame:Destroy()
+end
+
+local function renderPrompt(prompt)
+    removePrompt(prompt.id)
+
+    local card = Instance.new("Frame")
+    card.Name = prompt.id
+    card.Size = UDim2.new(1, 0, 0, 140)
+    card.BackgroundTransparency = 0.25
+    card.BackgroundColor3 = Color3.fromRGB(32, 32, 32)
+    card.LayoutOrder = -(prompt.priority or 0)
+    card.Parent = panel
+
+    local padding = Instance.new("UIPadding")
+    padding.PaddingTop = UDim.new(0, 8)
+    padding.PaddingBottom = UDim.new(0, 8)
+    padding.PaddingLeft = UDim.new(0, 10)
+    padding.PaddingRight = UDim.new(0, 10)
+    padding.Parent = card
+
+    local title = Instance.new("TextLabel")
+    title.Name = "Title"
+    title.Size = UDim2.new(1, -24, 0, 24)
+    title.BackgroundTransparency = 1
+    title.Font = Enum.Font.GothamBold
+    title.TextSize = 20
+    title.TextXAlignment = Enum.TextXAlignment.Left
+    title.TextColor3 = Color3.new(1, 1, 1)
+    title.Text = prompt.title or "Codex"
+    title.Parent = card
+
+    local status = Instance.new("TextLabel")
+    status.Name = "Status"
+    status.AnchorPoint = Vector2.new(1, 0)
+    status.Position = UDim2.new(1, 0, 0, 0)
+    status.Size = UDim2.new(0, 80, 0, 20)
+    status.BackgroundTransparency = 1
+    status.Font = Enum.Font.Gotham
+    status.TextSize = 14
+    status.TextXAlignment = Enum.TextXAlignment.Right
+    status.TextColor3 = Color3.fromRGB(200, 200, 200)
+    status.Parent = card
+
+    local body = Instance.new("TextLabel")
+    body.Name = "Body"
+    body.Size = UDim2.new(1, -4, 0, 60)
+    body.Position = UDim2.new(0, 0, 0, 36)
+    body.BackgroundTransparency = 1
+    body.Font = Enum.Font.Gotham
+    body.TextWrapped = true
+    body.TextXAlignment = Enum.TextXAlignment.Left
+    body.TextYAlignment = Enum.TextYAlignment.Top
+    body.TextSize = 16
+    body.TextColor3 = Color3.fromRGB(235, 235, 235)
+    body.Text = resolveBody(prompt.body)
+    body.Parent = card
+
+    local actionsContainer = Instance.new("Frame")
+    actionsContainer.Name = "Actions"
+    actionsContainer.Size = UDim2.new(1, 0, 0, 36)
+    actionsContainer.Position = UDim2.new(0, 0, 1, -44)
+    actionsContainer.BackgroundTransparency = 1
+    actionsContainer.Parent = card
+
+    local actionList = Instance.new("UIListLayout")
+    actionList.FillDirection = Enum.FillDirection.Horizontal
+    actionList.HorizontalAlignment = Enum.HorizontalAlignment.Left
+    actionList.Padding = UDim.new(0, 8)
+    actionList.Parent = actionsContainer
+
+    if typeof(prompt.actions) == "table" then
+        for _, action in ipairs(prompt.actions) do
+            local button = Instance.new("TextButton")
+            button.Size = UDim2.new(0, 120, 0, 32)
+            button.BackgroundColor3 = Color3.fromRGB(60, 120, 255)
+            button.TextColor3 = Color3.new(1, 1, 1)
+            button.Font = Enum.Font.GothamBold
+            button.TextSize = 16
+            button.TextWrapped = true
+            button.Text = action.label or "Action"
+            button.Parent = actionsContainer
+            button.MouseButton1Click:Connect(function()
+                sendAction(prompt.id, action)
+                showToast(action.label or prompt.title)
+            end)
+        end
+    end
+
+    local dismiss = Instance.new("TextButton")
+    dismiss.Size = UDim2.new(0, 100, 0, 32)
+    dismiss.BackgroundColor3 = Color3.fromRGB(80, 80, 80)
+    dismiss.TextColor3 = Color3.new(1, 1, 1)
+    dismiss.Font = Enum.Font.GothamBold
+    dismiss.TextSize = 16
+    dismiss.Text = "Dismiss"
+    dismiss.Parent = actionsContainer
+    dismiss.MouseButton1Click:Connect(function()
+        seenState[prompt.id] = true
+        removePrompt(prompt.id)
+        sendAck(prompt.id)
+        showToast(prompt.title)
+    end)
+
+    updateStatusLabel(status, prompt.id)
+
+    activePrompts[prompt.id] = {
+        frame = card,
+        status = status,
+    }
+
+    showToast(prompt.title)
+end
+
+local function syncState(state)
+    table.clear(seenState)
+    table.clear(completedState)
+    if typeof(state) ~= "table" then
+        return
+    end
+    if typeof(state.seen) == "table" then
+        for key, value in pairs(state.seen) do
+            if value then
+                seenState[key] = true
+            end
+        end
+    end
+    if typeof(state.completed) == "table" then
+        for key, value in pairs(state.completed) do
+            if value then
+                completedState[key] = true
+            end
+        end
+    end
+    for promptId, entry in pairs(activePrompts) do
+        updateStatusLabel(entry.status, promptId)
+    end
+end
+
+Net.TutorialEvent.OnClientEvent:Connect(function(message)
+    if typeof(message) ~= "table" then
+        return
+    end
+    if message.t == "SHOW_CODEX" and message.prompt then
+        renderPrompt(message.prompt)
+    elseif message.t == "HIDE_CODEX" and message.id then
+        removePrompt(message.id)
+    elseif message.t == "SYNC_CODEX" then
+        syncState(message.state)
+    end
+end)

--- a/src/StarterPlayer/StarterPlayerScripts/UI/Tutorial.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/UI/Tutorial.client.lua
@@ -32,10 +32,11 @@ local function hide()
 end
 
 Net.TutorialEvent.OnClientEvent:Connect(function(payload)
-	if not payload then return end
-	if payload.step == "fuel" then
-		show("Step 1: Tap +5 Fuel to feed the Beacon.")
-	elseif payload.step == "place" then
+        if not payload then return end
+        if payload.step == nil then return end
+        if payload.step == "fuel" then
+                show("Step 1: Tap +5 Fuel to feed the Beacon.")
+        elseif payload.step == "place" then
 		show("Step 2: Place a Wall near the beacon.")
 	elseif payload.step == "start" then
 		show("Step 3: Press Start Night.")

--- a/test/CodexService.spec.luau
+++ b/test/CodexService.spec.luau
@@ -1,0 +1,58 @@
+return function()
+    local CodexService = require(game.ServerScriptService.Services.CodexService)
+    local Players = game:GetService("Players")
+
+    local player = Instance.new("Player")
+    player.UserId = 98765
+    player.Name = "CodexTester"
+    player.Parent = Players
+
+    describe("CodexService gates", function()
+        it("evaluates beacon fuel thresholds", function()
+            local session = { shown = {}, cooldowns = {}, active = {} }
+            local ctx = {
+                world = { camp = { beaconFuel = 80, structures = {} }, day = 1 },
+                player = player,
+                profile = { codex = { seen = {}, completed = {} }, settings = { accessibility = { reduceFlashes = false } } },
+                session = session,
+            }
+            local prompt = { id = "fuel", gates = { { type = "BeaconFuelBelow", value = 60 } } }
+            expect(CodexService._test.canShow(ctx, prompt)).to.equal(false)
+            ctx.world.camp.beaconFuel = 40
+            session.shown = {}
+            session.cooldowns = {}
+            expect(CodexService._test.canShow(ctx, prompt)).to.equal(true)
+        end)
+
+        it("respects once per session", function()
+            local session = { shown = {}, cooldowns = {}, active = {} }
+            local ctx = {
+                world = { camp = { beaconFuel = 10, structures = {} }, day = 1 },
+                player = player,
+                profile = { codex = { seen = {}, completed = {} }, settings = {} },
+                session = session,
+            }
+            local prompt = { id = "session", gates = { { type = "OncePerSession" } } }
+            expect(CodexService._test.canShow(ctx, prompt)).to.equal(true)
+            session.shown.session = true
+            expect(CodexService._test.canShow(ctx, prompt)).to.equal(false)
+        end)
+
+        it("checks profile settings", function()
+            local session = { shown = {}, cooldowns = {}, active = {} }
+            local ctx = {
+                world = { camp = { beaconFuel = 10, structures = {} }, day = 1 },
+                player = player,
+                profile = { codex = { seen = {}, completed = {} }, settings = { accessibility = { reduceFlashes = false } } },
+                session = session,
+            }
+            local prompt = {
+                id = "access",
+                gates = { { type = "ProfileSettingEquals", category = "accessibility", key = "reduceFlashes", value = false } },
+            }
+            expect(CodexService._test.canShow(ctx, prompt)).to.equal(true)
+            ctx.profile.settings.accessibility.reduceFlashes = true
+            expect(CodexService._test.canShow(ctx, prompt)).to.equal(false)
+        end)
+    end)
+end

--- a/test/DataService.spec.luau
+++ b/test/DataService.spec.luau
@@ -1,12 +1,21 @@
 return function()
 	local Data = require(game.ServerScriptService.Services.DataService)
 	local fake = { UserId = 123 }
-	describe("DataService basic ops", function()
-		it("loads and adds shards", function()
-			local p = Data.LoadProfileAsync(fake)
-			local before = p.currencies.shards
-			Data.AddShards(fake, 5)
-			assert(p.currencies.shards == before + 5, "shards should increase")
-		end)
-	end)
+        describe("DataService basic ops", function()
+                it("loads and adds shards", function()
+                        local p = Data.LoadProfileAsync(fake)
+                        local before = p.currencies.shards
+                        Data.AddShards(fake, 5)
+                        assert(p.currencies.shards == before + 5, "shards should increase")
+                end)
+
+                it("tracks codex flags", function()
+                        Data.LoadProfileAsync(fake)
+                        Data.MarkCodexSeen(fake, "intro")
+                        Data.MarkCodexCompleted(fake, "intro")
+                        local snap = Data.GetProfileSnapshot(fake)
+                        assert(snap.codex.seen.intro == true, "seen flag stored")
+                        assert(snap.codex.completed.intro == true, "completed flag stored")
+                end)
+        end)
 end


### PR DESCRIPTION
## Summary
- add a CodexService that evaluates prompt gates, manages world state, and logs codex analytics
- author the initial prompt catalog with localization data and surface it through a new Codex HUD client
- hook existing services to emit codex triggers and extend DataService/tests to persist codex progress

## Testing
- ./scripts/run-tests.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691008820880832381de1eae92b668c5)