### PR TITLE
Implement phase and beacon MVP loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ Survive 99: Evolved is a mobile-first Roblox co-op survival/base-defense game. P
 
 Combat, resources, building, rewards, purchases, player health, revives, Beacon state, enemy spawning, wave outcomes, and persistence must be validated and finalized server-side. Clients may request actions and render feedback, but must never be trusted for damage, placement legality, currency balances, inventory changes, purchase grants, or saved data.
 
+Phase and Beacon work should build on `src/ServerScriptService/Services/PhaseService.lua`, `BeaconService.lua`, and server-owned remotes rather than replacing them or moving authority to clients.
+
 ## Mobile-first rule
 
 UI and controls must be readable and usable on phones first. Use large touch targets, short labels, clear contrast, safe-area awareness, simple input flows, and scalable HUD layouts. Desktop and gamepad support should not compromise mobile usability.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is an existing Roblox/Rojo Luau project with both:
 - A canonical Rojo `src/` tree mapped by `default.project.json`.
 - Legacy starter roots (`Client/`, `Server/`, `Shared/`) and existing test folders (`test/`, `Tests/`) that should be preserved until a focused migration/cleanup PR confirms what is still useful.
 
-This foundation pass intentionally does **not** implement the full game. It establishes documentation, Rojo mapping, shared constants, and core starter config modules for future work.
+This project now includes the first tightly scoped server-authoritative loop: `RemoteService` creates named read-only remotes, `BeaconService` owns Beacon HP/shield/fuel state, and `PhaseService` advances through Lobby/Day/Dusk/Night/Dawn for client display. It still intentionally does **not** implement the full game.
 
 ## Expected tools
 
@@ -63,7 +63,7 @@ rojo build default.project.json --output build.rbxlx
 │   │       │   ├── Enemies.lua
 │   │       │   ├── Omens.lua
 │   │       │   └── Bosses.lua
-│   │       └── Remotes/
+│   │       └── Remotes/RemoteNames.lua
 │   ├── ServerScriptService/
 │   │   ├── Services/
 │   │   └── Systems/
@@ -78,7 +78,7 @@ rojo build default.project.json --output build.rbxlx
 
 ## Validation
 
-Run the available validation commands for your environment:
+Run the available validation commands for your environment. For the phase/beacon MVP, also follow [`docs/VALIDATION_PHASE_BEACON.md`](docs/VALIDATION_PHASE_BEACON.md) in Roblox Studio because the current shell test runner is a placeholder.
 
 ```sh
 rojo build default.project.json --output build.rbxlx
@@ -102,7 +102,7 @@ If a command is unavailable locally, install the project-standard tool or report
 ## Milestone roadmap
 
 1. **Foundation** — canonical docs, Rojo mapping, shared constants, and core config modules.
-2. **Core loop prototype** — day/night state machine, Beacon health/fuel, simple gathering, and server-validated building requests.
+2. **Core loop prototype** — day/night state machine and Beacon health/fuel are started; simple gathering and server-validated building requests remain future small PRs.
 3. **Combat prototype** — server-authoritative enemy spawning, player attacks, damage, revives, and basic wave resolution.
 4. **Base defense** — structures, traps, repairs, placement validation, and mobile build UI.
 5. **Progression and rewards** — fair run rewards, cosmetics-first persistence, analytics hooks, and anti-exploit checks.
@@ -111,4 +111,4 @@ If a command is unavailable locally, install the project-standard tool or report
 
 ## Recommended next Codex task
 
-Implement the first small playable server-authoritative loop: a minimal day/night phase service that updates Beacon state, exposes read-only phase updates through named remotes, and includes tests or Studio validation notes without adding client-authoritative gameplay.
+Implement MVP team resource inventory + deposit service, without building placement yet.

--- a/docs/VALIDATION_PHASE_BEACON.md
+++ b/docs/VALIDATION_PHASE_BEACON.md
@@ -1,0 +1,26 @@
+# Phase + Beacon MVP Validation
+
+This repository's shell test runner is currently a placeholder, so this checklist captures Roblox Studio validation for the first server-authoritative phase/beacon loop.
+
+## Studio validation steps
+
+1. Open the place from Rojo (`rojo serve default.project.json`) or build/sync the project into Roblox Studio.
+2. Start a local Roblox Studio test server with at least one client.
+3. Confirm the server initializes `RemoteService`, `BeaconService`, and `PhaseService` without errors.
+4. Confirm `ReplicatedStorage/Remotes` contains server-created `PhaseStateChanged`, `BeaconStateChanged`, and `RequestNightStartVote` remotes.
+5. Confirm phase state progresses through `Lobby -> Day -> Dusk -> Night -> Dawn -> Day`.
+6. Confirm the `PhaseBeaconHUD` client display receives `PhaseStateChanged` and shows the current phase, night number, and countdown.
+7. Confirm the client receives `BeaconStateChanged` and shows Beacon HP/shield.
+8. From the server console, call BeaconService methods to confirm clamping:
+   - `Damage(amount)` reduces shield first, then HP.
+   - `Heal(amount)` clamps HP at max HP.
+   - `SetHealth(value)` clamps HP between `0` and `maxHp`.
+   - `SetShield(value)` clamps shield between `0` and `maxShield`.
+9. Confirm no client script directly mutates phase or beacon state; clients only listen to read-only remote updates.
+
+## Current skipped validation warnings
+
+- `rojo build default.project.json --output build.rbxlx` may be skipped when Rojo is not installed in PATH.
+- `stylua --check .` may be skipped when Stylua is not installed in PATH.
+- `selene .` may be skipped when Selene is not installed in PATH.
+- `./scripts/run-tests.sh` is currently a placeholder and does not execute real TestEZ/Luau tests yet.

--- a/src/ReplicatedStorage/Shared/Constants.lua
+++ b/src/ReplicatedStorage/Shared/Constants.lua
@@ -10,6 +10,7 @@ Constants.PHASES = {
 	DAY = "Day",
 	DUSK = "Dusk",
 	NIGHT = "Night",
+	DAWN = "Dawn",
 	BOSS = "Boss",
 	ESCAPE = "Escape",
 	RESULTS = "Results",
@@ -30,6 +31,27 @@ Constants.REMOTES = {
 	STATE_INVENTORY = "StateInventory",
 	STATE_WAVE = "StateWave",
 	UX_NOTIFICATION = "UxNotification",
+	PHASE_STATE_CHANGED = "PhaseStateChanged",
+	BEACON_STATE_CHANGED = "BeaconStateChanged",
+	REQUEST_NIGHT_START_VOTE = "RequestNightStartVote",
+}
+
+Constants.DEFAULT_BEACON = {
+	maxHp = 1000,
+	hp = 1000,
+	maxShield = 0,
+	shield = 0,
+	fuel = 0,
+	level = 1,
+	auraRadius = 60,
+}
+
+Constants.PHASE_DURATIONS = {
+	[Constants.PHASES.LOBBY] = 10,
+	[Constants.PHASES.DAY] = 120,
+	[Constants.PHASES.DUSK] = 10,
+	[Constants.PHASES.NIGHT] = 120,
+	[Constants.PHASES.DAWN] = 10,
 }
 
 Constants.DEFAULT_PLAYER_STATS = {

--- a/src/ReplicatedStorage/Shared/Remotes/RemoteNames.lua
+++ b/src/ReplicatedStorage/Shared/Remotes/RemoteNames.lua
@@ -1,0 +1,11 @@
+-- Central names for runtime remotes. Server code owns creation under
+-- ReplicatedStorage/Remotes; client code should only look these up.
+local Constants = require(script.Parent.Parent.Constants)
+
+local RemoteNames = {
+	PhaseStateChanged = Constants.REMOTES.PHASE_STATE_CHANGED,
+	BeaconStateChanged = Constants.REMOTES.BEACON_STATE_CHANGED,
+	RequestNightStartVote = Constants.REMOTES.REQUEST_NIGHT_START_VOTE,
+}
+
+return RemoteNames

--- a/src/ServerScriptService/Server/Server.main.server.lua
+++ b/src/ServerScriptService/Server/Server.main.server.lua
@@ -29,7 +29,9 @@ local BugReport = require(ServicesFolder.BugReportService)
 BugReport.Start()
 local GameService = require(ServicesFolder.GameService)
 local DataService = require(ServicesFolder.DataService)
+local RemoteService = require(ServicesFolder.RemoteService)
 local BeaconService = require(ServicesFolder.BeaconService)
+local PhaseService = require(ServicesFolder.PhaseService)
 local TutorialService = require(ServicesFolder.TutorialService)
 local PatchNotes = require(ServicesFolder.PatchNotesService)
 local CodexService = require(ServicesFolder.CodexService)
@@ -46,6 +48,11 @@ game.Players.PlayerRemoving:Connect(function(plr)
         CodexService.OnPlayerRemoving(plr)
         DataService.SaveProfileAsync(plr)
 end)
+
+RemoteService.Init()
+BeaconService.Init()
+PhaseService.Init()
+PhaseService.Start()
 
 SurvivalService.Start()
 CombatService.Start()
@@ -67,5 +74,8 @@ RunService.Stepped:Connect(function(_, dt)
 	for _, sys in systemFns do sys(World, dt) end
 end)
 
--- Ensure beacon UI gets an initial push
-task.delay(0.5, function() local s = BeaconService.GetState and BeaconService.GetState() if s then require(ReplicatedStorage.Remotes.Net).BeaconChanged:FireAllClients(s) end end)
+-- Ensure clients that join during bootstrap receive initial read-only state.
+task.delay(0.5, function()
+	BeaconService.BroadcastState()
+	PhaseService.BroadcastState()
+end)

--- a/src/ServerScriptService/Services/BeaconService.lua
+++ b/src/ServerScriptService/Services/BeaconService.lua
@@ -1,92 +1,225 @@
-local Rep = game:GetService("ReplicatedStorage")
-local Net = require(Rep.Remotes.Net)
-local C = require(Rep.Shared.Constants)
-local Tuning = require(Rep.Shared.Config.Tuning)
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Net = require(ReplicatedStorage.Remotes.Net)
+local Constants = require(ReplicatedStorage.Shared.Constants)
+local Tuning = require(ReplicatedStorage.Shared.Config.Tuning)
+local RemoteNames = require(ReplicatedStorage.Shared.Remotes.RemoteNames)
 local OmenService = require(script.Parent.OmenService)
 local CodexService = require(script.Parent.CodexService)
+local RemoteService = require(script.Parent.RemoteService)
 
-local M = {}
-local state = { fuel = 100, heat = 100, lightRadius = 90, stability = 1, mods = {} }
-local function clamp(x, a, b) return math.max(a, math.min(b, x)) end
-local function fire() Net.BeaconChanged:FireAllClients(table.freeze(table.clone(state))) end
+local BeaconService = {}
+
+local defaults = Constants.DEFAULT_BEACON
+local state = {
+	hp = defaults.hp,
+	maxHp = defaults.maxHp,
+	shield = defaults.shield,
+	maxShield = defaults.maxShield,
+	fuel = defaults.fuel,
+	level = defaults.level,
+	auraRadius = defaults.auraRadius,
+	destroyed = false,
+
+	-- Compatibility fields read by existing legacy systems until a focused cleanup PR.
+	heat = 100,
+	lightRadius = defaults.auraRadius,
+	stability = 1,
+	mods = {},
+}
+
+local initialized = false
 local lastFuelMilestone = nil
 
--- world beacon instance (simple Part if none)
-local function ensureBeacon()
-	local b = workspace:FindFirstChild("Beacon")
-        if not b then
-                b = Instance.new("Part")
-                b.Name = "Beacon"; b.Anchored = true; b.CanCollide = false; b.Size = Vector3.new(4,8,4)
-                b.Position = Vector3.new(0,4,0); b.Material = Enum.Material.Neon
-                b.Color = Color3.fromRGB(255, 214, 120); b.Parent = workspace
-        end
-        CodexService.UpdateWorldState({ camp = { position = b.Position } })
-        return b
+local function clamp(value: number, minValue: number, maxValue: number): number
+	return math.max(minValue, math.min(maxValue, value))
 end
 
-function M.GetCFrame() return ensureBeacon().CFrame end
-function M.GetState() return state end
-function M.ApplyFuel(n)
-        state.fuel = clamp(state.fuel + (n or 0), 0, 100)
-        CodexService.UpdateWorldState({ camp = { beaconFuel = state.fuel } })
-        if state.fuel < 60 then
-                CodexService.Emit("BEACON_FUEL_LOW", { fuel = state.fuel })
-        end
-        if state.fuel >= 95 then
-                if lastFuelMilestone ~= 100 then
-                        lastFuelMilestone = 100
-                        CodexService.Emit("BEACON_FUEL_MILESTONE", { fuel = state.fuel })
-                end
-        else
-                lastFuelMilestone = nil
-        end
-        fire()
-        return state.fuel
+local function copyState()
+	local snapshot = table.clone(state)
+	snapshot.mods = table.clone(state.mods)
+	return snapshot
+end
+
+local function updateDestroyed()
+	state.destroyed = state.hp <= 0
+end
+
+local function publishLegacyBeaconChanged(snapshot)
+	-- Legacy UI/scripts still listen to BeaconChanged. The new authoritative read-only
+	-- channel for this milestone is BeaconStateChanged.
+	Net.BeaconChanged:FireAllClients(snapshot)
+end
+
+function BeaconService.BroadcastState()
+	local snapshot = copyState()
+	local beaconChanged = RemoteService.GetEvent(RemoteNames.BeaconStateChanged)
+	if beaconChanged then
+		beaconChanged:FireAllClients(snapshot)
+	end
+	publishLegacyBeaconChanged(snapshot)
+end
+
+local function ensureBeacon()
+	local beacon = workspace:FindFirstChild("Beacon")
+	if not beacon then
+		beacon = Instance.new("Part")
+		beacon.Name = "Beacon"
+		beacon.Anchored = true
+		beacon.CanCollide = false
+		beacon.Size = Vector3.new(4, 8, 4)
+		beacon.Position = Vector3.new(0, 4, 0)
+		beacon.Material = Enum.Material.Neon
+		beacon.Color = Color3.fromRGB(255, 214, 120)
+		beacon.Parent = workspace
+	end
+
+	CodexService.UpdateWorldState({ camp = { position = beacon.Position } })
+	return beacon
+end
+
+function BeaconService.Init()
+	if initialized then
+		return
+	end
+
+	RemoteService.Init()
+	ensureBeacon()
+	updateDestroyed()
+	initialized = true
+	BeaconService.BroadcastState()
+end
+
+function BeaconService.GetCFrame()
+	return ensureBeacon().CFrame
+end
+
+function BeaconService.GetState()
+	return copyState()
+end
+
+function BeaconService.SetHealth(value: number)
+	local numericValue = tonumber(value) or state.hp
+	state.hp = clamp(numericValue, 0, state.maxHp)
+	updateDestroyed()
+	BeaconService.BroadcastState()
+	return state.hp
+end
+
+function BeaconService.SetShield(value: number)
+	local numericValue = tonumber(value) or state.shield
+	state.shield = clamp(numericValue, 0, state.maxShield)
+	BeaconService.BroadcastState()
+	return state.shield
+end
+
+function BeaconService.Damage(amount: number, _source: any?)
+	local remaining = math.max(tonumber(amount) or 0, 0)
+	if remaining <= 0 or state.destroyed then
+		return BeaconService.GetState()
+	end
+
+	local shieldDamage = math.min(state.shield, remaining)
+	state.shield -= shieldDamage
+	remaining -= shieldDamage
+
+	if remaining > 0 then
+		state.hp = clamp(state.hp - remaining, 0, state.maxHp)
+	end
+
+	updateDestroyed()
+	BeaconService.BroadcastState()
+	return BeaconService.GetState()
+end
+
+function BeaconService.Heal(amount: number, _source: any?)
+	local healing = math.max(tonumber(amount) or 0, 0)
+	if healing <= 0 then
+		return BeaconService.GetState()
+	end
+
+	state.hp = clamp(state.hp + healing, 0, state.maxHp)
+	updateDestroyed()
+	BeaconService.BroadcastState()
+	return BeaconService.GetState()
+end
+
+function BeaconService.ApplyFuel(amount: number)
+	state.fuel = clamp(state.fuel + (tonumber(amount) or 0), 0, 100)
+	CodexService.UpdateWorldState({ camp = { beaconFuel = state.fuel } })
+	if state.fuel < 60 then
+		CodexService.Emit("BEACON_FUEL_LOW", { fuel = state.fuel })
+	end
+	if state.fuel >= 95 then
+		if lastFuelMilestone ~= 100 then
+			lastFuelMilestone = 100
+			CodexService.Emit("BEACON_FUEL_MILESTONE", { fuel = state.fuel })
+		end
+	else
+		lastFuelMilestone = nil
+	end
+	BeaconService.BroadcastState()
+	return state.fuel
 end
 
 local modHandlers = {
-	RadiusPlus = function(en) state.lightRadius = en and 110 or 90 end,
-	Fortify   = function(_)  end, -- handled by BuildService reading this mod
-	Siphon    = function(_)  end, -- handled in AI death hooks (future)
-	Lure      = function(_)  end,
-	Warmth    = function(_)  end,
+	RadiusPlus = function(enabled)
+		state.auraRadius = enabled and 110 or defaults.auraRadius
+		state.lightRadius = state.auraRadius
+	end,
+	Fortify = function(_) end,
+	Siphon = function(_) end,
+	Lure = function(_) end,
+	Warmth = function(_) end,
 	GuardianPulse = function(_) end,
 }
 
-function M.InstallMod(id)
-	if not modHandlers[id] then return false end
-	if state.mods[id] then return true end
-	state.mods[id] = true; modHandlers[id](true); fire(); return true
+function BeaconService.InstallMod(id: string)
+	if not modHandlers[id] then
+		return false
+	end
+	if state.mods[id] then
+		return true
+	end
+	state.mods[id] = true
+	modHandlers[id](true)
+	BeaconService.BroadcastState()
+	return true
 end
 
-function M.RemoveMod(id)
-	if not state.mods[id] then return false end
-	state.mods[id] = nil; modHandlers[id](false); fire(); return true
+function BeaconService.RemoveMod(id: string)
+	if not state.mods[id] then
+		return false
+	end
+	state.mods[id] = nil
+	modHandlers[id](false)
+	BeaconService.BroadcastState()
+	return true
 end
 
--- Day/Night hooks
-function M.OnDayStart()
-        state.heat = clamp(state.heat + C.Beacon.HeatRecoveryPerDay, 0, 100)
-        CodexService.UpdateWorldState({ camp = { beaconFuel = state.fuel } })
-        fire()
+function BeaconService.OnDayStart()
+	state.heat = clamp(state.heat + Constants.Beacon.HeatRecoveryPerDay, 0, 100)
+	CodexService.UpdateWorldState({ camp = { beaconFuel = state.fuel } })
+	BeaconService.BroadcastState()
 end
 
-function M.OnNightStart()
-  local extra = 0
-  if OmenService.Is("BloodMoon") then
-    local O = (Tuning.get().Omen and Tuning.get().Omen.BloodMoon) or { extraFuel = 2 }
-    extra = O.extraFuel or 2
-  end
-  state.fuel = clamp(state.fuel - (C.Beacon.FuelDrainPerNight + extra), 0, 100)
-        Net.SpawnVFX:FireAllClients({ kind="particle", position = M.GetCFrame().Position })
-        Net.PlaySound:FireAllClients("beacon_on")
-        if state.fuel <= 0 then
-                Net.PlaySound:FireAllClients("beacon_off")
-                warn("[Beacon] Blackout!")
-                Net.BroadcastState:FireAllClients({ blackout = true })
-        end
-        CodexService.UpdateWorldState({ camp = { beaconFuel = state.fuel } })
-        fire()
+function BeaconService.OnNightStart()
+	local extra = 0
+	if OmenService.Is("BloodMoon") then
+		local omenTuning = (Tuning.get().Omen and Tuning.get().Omen.BloodMoon) or { extraFuel = 2 }
+		extra = omenTuning.extraFuel or 2
+	end
+
+	state.fuel = clamp(state.fuel - (Constants.Beacon.FuelDrainPerNight + extra), 0, 100)
+	Net.SpawnVFX:FireAllClients({ kind = "particle", position = BeaconService.GetCFrame().Position })
+	Net.PlaySound:FireAllClients("beacon_on")
+	if state.fuel <= 0 then
+		Net.PlaySound:FireAllClients("beacon_off")
+		warn("[Beacon] Blackout!")
+		Net.BroadcastState:FireAllClients({ blackout = true })
+	end
+	CodexService.UpdateWorldState({ camp = { beaconFuel = state.fuel } })
+	BeaconService.BroadcastState()
 end
 
-return M
+return BeaconService

--- a/src/ServerScriptService/Services/PhaseService.lua
+++ b/src/ServerScriptService/Services/PhaseService.lua
@@ -1,0 +1,148 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Constants = require(ReplicatedStorage.Shared.Constants)
+local RemoteNames = require(ReplicatedStorage.Shared.Remotes.RemoteNames)
+local RemoteService = require(script.Parent.RemoteService)
+
+local PhaseService = {}
+
+local PHASES = Constants.PHASES
+local PHASE_ORDER = {
+	PHASES.LOBBY,
+	PHASES.DAY,
+	PHASES.DUSK,
+	PHASES.NIGHT,
+	PHASES.DAWN,
+}
+
+local DEV_FAST_PHASES = false
+local DEV_PHASE_DURATIONS = {
+	[PHASES.LOBBY] = 3,
+	[PHASES.DAY] = 10,
+	[PHASES.DUSK] = 3,
+	[PHASES.NIGHT] = 10,
+	[PHASES.DAWN] = 3,
+}
+
+local initialized = false
+local running = false
+local loopToken = 0
+
+local state = {
+	phase = PHASES.LOBBY,
+	night = 0,
+	phaseStartedAt = 0,
+	duration = Constants.PHASE_DURATIONS[PHASES.LOBBY],
+	endsAt = 0,
+	omen = nil,
+}
+
+local function now(): number
+	return workspace:GetServerTimeNow()
+end
+
+local function getDuration(phase: string): number
+	local durations = DEV_FAST_PHASES and DEV_PHASE_DURATIONS or Constants.PHASE_DURATIONS
+	return durations[phase] or 10
+end
+
+local function copyState()
+	return table.clone(state)
+end
+
+local function phaseIndex(phase: string): number
+	for index, phaseName in ipairs(PHASE_ORDER) do
+		if phaseName == phase then
+			return index
+		end
+	end
+	return 1
+end
+
+local function enterPhase(phase: string)
+	local timestamp = now()
+	state.phase = phase
+	state.phaseStartedAt = timestamp
+	state.duration = getDuration(phase)
+	state.endsAt = timestamp + state.duration
+	state.omen = nil
+
+	-- The night number labels the upcoming/current survival night. It becomes 1
+	-- when the first Day starts, then increments after each Dawn as the next Day starts.
+	if phase == PHASES.DAY then
+		state.night += 1
+	end
+end
+
+function PhaseService.BroadcastState()
+	local phaseChanged = RemoteService.GetEvent(RemoteNames.PhaseStateChanged)
+	if phaseChanged then
+		phaseChanged:FireAllClients(copyState())
+	end
+end
+
+function PhaseService.Init()
+	if initialized then
+		return
+	end
+
+	RemoteService.Init()
+	enterPhase(PHASES.LOBBY)
+	initialized = true
+	PhaseService.BroadcastState()
+end
+
+function PhaseService.Start()
+	if running then
+		return
+	end
+
+	if not initialized then
+		PhaseService.Init()
+	end
+
+	running = true
+	loopToken += 1
+	local token = loopToken
+	PhaseService.BroadcastState()
+
+	task.spawn(function()
+		while running and token == loopToken do
+			local timestamp = now()
+			if timestamp >= state.endsAt then
+				PhaseService.AdvancePhase()
+			else
+				-- Lightweight read-only countdown updates for the MVP HUD, capped at once per second.
+				PhaseService.BroadcastState()
+			end
+			task.wait(1)
+		end
+	end)
+end
+
+function PhaseService.Stop()
+	if not running then
+		return
+	end
+
+	running = false
+	loopToken += 1
+end
+
+function PhaseService.GetState()
+	return copyState()
+end
+
+function PhaseService.AdvancePhase()
+	local currentIndex = phaseIndex(state.phase)
+	local nextIndex = currentIndex + 1
+	if nextIndex > #PHASE_ORDER then
+		nextIndex = 2 -- After Dawn, continue with Day; Lobby only happens at server start.
+	end
+
+	enterPhase(PHASE_ORDER[nextIndex])
+	PhaseService.BroadcastState()
+	return PhaseService.GetState()
+end
+
+return PhaseService

--- a/src/ServerScriptService/Services/RemoteService.lua
+++ b/src/ServerScriptService/Services/RemoteService.lua
@@ -1,0 +1,74 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local RemoteNames = require(ReplicatedStorage.Shared.Remotes.RemoteNames)
+
+local RemoteService = {}
+local initialized = false
+local remotesFolder: Folder? = nil
+
+local REMOTE_CLASSES = {
+	[RemoteNames.PhaseStateChanged] = "RemoteEvent",
+	[RemoteNames.BeaconStateChanged] = "RemoteEvent",
+	[RemoteNames.RequestNightStartVote] = "RemoteEvent",
+}
+
+local function getFolder(): Folder
+	local folder = remotesFolder or ReplicatedStorage:FindFirstChild("Remotes")
+	if not folder then
+		folder = Instance.new("Folder")
+		folder.Name = "Remotes"
+		folder.Parent = ReplicatedStorage
+	end
+
+	remotesFolder = folder :: Folder
+	return remotesFolder :: Folder
+end
+
+local function ensureRemote(name: string, className: string): Instance
+	local folder = getFolder()
+	local existing = folder:FindFirstChild(name)
+	if existing then
+		if not existing:IsA(className) then
+			warn(string.format("[RemoteService] %s exists as %s, expected %s", name, existing.ClassName, className))
+		end
+		return existing
+	end
+
+	local remote = Instance.new(className)
+	remote.Name = name
+	remote.Parent = folder
+	return remote
+end
+
+function RemoteService.Init()
+	if initialized then
+		return
+	end
+
+	for name, className in pairs(REMOTE_CLASSES) do
+		ensureRemote(name, className)
+	end
+
+	initialized = true
+end
+
+function RemoteService.GetRemote(name: string): Instance?
+	local className = REMOTE_CLASSES[name]
+	if not className then
+		warn(string.format("[RemoteService] Unknown remote requested: %s", name))
+		return nil
+	end
+
+	return ensureRemote(name, className)
+end
+
+function RemoteService.GetEvent(name: string): RemoteEvent?
+	local remote = RemoteService.GetRemote(name)
+	if remote and remote:IsA("RemoteEvent") then
+		return remote
+	end
+
+	return nil
+end
+
+return RemoteService

--- a/src/StarterPlayer/StarterPlayerScripts/PhaseBeaconClient.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/PhaseBeaconClient.client.lua
@@ -1,0 +1,114 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local RemoteNames = require(ReplicatedStorage.Shared.Remotes.RemoteNames)
+
+local player = Players.LocalPlayer
+local remotes = ReplicatedStorage:WaitForChild("Remotes")
+local phaseStateChanged = remotes:WaitForChild(RemoteNames.PhaseStateChanged)
+local beaconStateChanged = remotes:WaitForChild(RemoteNames.BeaconStateChanged)
+
+local gui = Instance.new("ScreenGui")
+gui.Name = "PhaseBeaconHUD"
+gui.ResetOnSpawn = false
+gui.IgnoreGuiInset = false
+gui.Parent = player:WaitForChild("PlayerGui")
+
+local panel = Instance.new("Frame")
+panel.Name = "Panel"
+panel.AnchorPoint = Vector2.new(1, 0)
+panel.Position = UDim2.new(1, -12, 0, 12)
+panel.Size = UDim2.new(0, 300, 0, 112)
+panel.BackgroundColor3 = Color3.fromRGB(12, 18, 28)
+panel.BackgroundTransparency = 0.18
+panel.BorderSizePixel = 0
+panel.Parent = gui
+
+local corner = Instance.new("UICorner")
+corner.CornerRadius = UDim.new(0, 10)
+corner.Parent = panel
+
+local padding = Instance.new("UIPadding")
+padding.PaddingTop = UDim.new(0, 10)
+padding.PaddingBottom = UDim.new(0, 10)
+padding.PaddingLeft = UDim.new(0, 12)
+padding.PaddingRight = UDim.new(0, 12)
+padding.Parent = panel
+
+local layout = Instance.new("UIListLayout")
+layout.FillDirection = Enum.FillDirection.Vertical
+layout.HorizontalAlignment = Enum.HorizontalAlignment.Left
+layout.VerticalAlignment = Enum.VerticalAlignment.Top
+layout.Padding = UDim.new(0, 4)
+layout.Parent = panel
+
+local function makeLabel(name: string): TextLabel
+	local label = Instance.new("TextLabel")
+	label.Name = name
+	label.Size = UDim2.new(1, 0, 0, 28)
+	label.BackgroundTransparency = 1
+	label.Font = Enum.Font.GothamBold
+	label.TextColor3 = Color3.fromRGB(245, 248, 255)
+	label.TextSize = 20
+	label.TextXAlignment = Enum.TextXAlignment.Left
+	label.TextYAlignment = Enum.TextYAlignment.Center
+	label.Parent = panel
+	return label
+end
+
+local phaseLabel = makeLabel("Phase")
+local timeLabel = makeLabel("TimeRemaining")
+local beaconLabel = makeLabel("Beacon")
+
+local latestPhase = nil
+local latestBeacon = nil
+
+local function secondsRemaining(phaseState): number
+	local endsAt = phaseState and phaseState.endsAt or 0
+	return math.max(0, math.ceil(endsAt - workspace:GetServerTimeNow()))
+end
+
+local function render()
+	if latestPhase then
+		phaseLabel.Text = string.format("Night %d • %s", latestPhase.night or 0, latestPhase.phase or "Lobby")
+		timeLabel.Text = string.format("Time remaining: %ds", secondsRemaining(latestPhase))
+	else
+		phaseLabel.Text = "Night 0 • Waiting"
+		timeLabel.Text = "Time remaining: --"
+	end
+
+	if latestBeacon then
+		beaconLabel.Text = string.format(
+			"Beacon: %d/%d HP • %d/%d Shield",
+			math.floor(latestBeacon.hp or 0),
+			math.floor(latestBeacon.maxHp or 0),
+			math.floor(latestBeacon.shield or 0),
+			math.floor(latestBeacon.maxShield or 0)
+		)
+	else
+		beaconLabel.Text = "Beacon: waiting for state"
+	end
+end
+
+phaseStateChanged.OnClientEvent:Connect(function(phaseState)
+	latestPhase = phaseState
+	print(string.format(
+		"[PhaseBeaconHUD] Phase update: night=%s phase=%s",
+		tostring(phaseState.night),
+		tostring(phaseState.phase)
+	))
+	render()
+end)
+
+beaconStateChanged.OnClientEvent:Connect(function(beaconState)
+	latestBeacon = beaconState
+	print(string.format(
+		"[PhaseBeaconHUD] Beacon update: hp=%s shield=%s fuel=%s",
+		tostring(beaconState.hp),
+		tostring(beaconState.shield),
+		tostring(beaconState.fuel)
+	))
+	render()
+end)
+
+render()


### PR DESCRIPTION
### Motivation
- Deliver the first small, server-authoritative playable slice: a minimal day/night phase loop and a server-owned Beacon state so clients only receive read-only updates, per the project SPEC and PR scope.
- Provide a small, discoverable remote naming surface and server bootstrap so future systems can subscribe to authoritative phase/beacon state without moving authority to clients.

### Description
- Added centralized remote names in `src/ReplicatedStorage/Shared/Remotes/RemoteNames.lua` and a server `RemoteService` at `src/ServerScriptService/Services/RemoteService.lua` that creates/ensures `PhaseStateChanged`, `BeaconStateChanged`, and `RequestNightStartVote` under `ReplicatedStorage/Remotes`.
- Reworked `BeaconService` at `src/ServerScriptService/Services/BeaconService.lua` to own server-side Beacon state (`hp`, `maxHp`, `shield`, `maxShield`, `fuel`, `level`, `auraRadius`, `destroyed`) with `Init()`, `GetState()`, `SetHealth()`, `SetShield()`, `Damage()`, `Heal()`, `ApplyFuel()`, and `BroadcastState()` implementing clamping and shield-first damage while preserving legacy compatibility hooks.
- Added `PhaseService` at `src/ServerScriptService/Services/PhaseService.lua` implementing a minimal `Lobby -> Day -> Dusk -> Night -> Dawn` loop with `Init()`, `Start()`, `Stop()`, `AdvancePhase()`, and `BroadcastState()` and documented night-counter semantics and optional dev fast-phase durations.
- Bootstrapped services in the server entrypoint by initializing `RemoteService`, `BeaconService`, and `PhaseService` and sending an initial read-only state push; updated `README.md` and `AGENTS.md` to note the new services and guidance.
- Added a tiny, mobile-friendly client listener HUD `src/StarterPlayer/StarterPlayerScripts/PhaseBeaconClient.client.lua` that waits for the server remotes and displays phase, countdown, and Beacon HP/shield, and added `docs/VALIDATION_PHASE_BEACON.md` with Studio validation steps.

### Testing
- Ran the repository test runner with `./scripts/run-tests.sh`, which executed successfully but is intentionally a placeholder and does not run real TestEZ/Luau tests.
- Attempted `rojo build default.project.json --output build.rbxlx`, `stylua --check .`, and `selene .`, all of which were not run because the tools are not available in the environment (`rojo`, `stylua`, and `selene` returned `command not found`).
- Verified via repository checks that the new files were staged and committed and that the server bootstrap now calls `RemoteService.Init()`, `BeaconService.Init()`, and `PhaseService.Start()` so remotes and initial state are created at runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0604fe949483239ff4e52c86ed3d29)